### PR TITLE
LOOP-4858 Add new timeline based basal overlay to replace schedule based overlay

### DIFF
--- a/Sources/LoopAlgorithm/AbsoluteScheduleValue.swift
+++ b/Sources/LoopAlgorithm/AbsoluteScheduleValue.swift
@@ -16,6 +16,10 @@ public struct AbsoluteScheduleValue<T>: TimelineValue {
         self.endDate = endDate
         self.value = value
     }
+
+    public var duration: TimeInterval {
+        return endDate.timeIntervalSince(startDate)
+    }
 }
 
 extension AbsoluteScheduleValue: Equatable where T: Equatable {}

--- a/Sources/LoopAlgorithm/Insulin/DoseMath.swift
+++ b/Sources/LoopAlgorithm/Insulin/DoseMath.swift
@@ -194,6 +194,10 @@ extension Array where Element: GlucoseValue {
 
         let endOfAbsorption = date.addingTimeInterval(model.effectDuration)
 
+        guard let correctionRangeItem = correctionRange.closestPrior(to: date) else {
+            preconditionFailure("Correction range must cover date: \(date)")
+        }
+
         // For each prediction above target, determine the amount of insulin necessary to correct glucose based on the modeled effectiveness of the insulin at that time
         for prediction in self {
             guard prediction.startDate >= date else {
@@ -209,10 +213,6 @@ extension Array where Element: GlucoseValue {
 
             let predictedGlucoseValue = prediction.quantity.doubleValue(for: unit)
             let time = prediction.startDate.timeIntervalSince(date)
-
-            guard let correctionRangeItem = correctionRange.closestPrior(to: prediction.startDate) else {
-                preconditionFailure("Correction range must cover date: \(prediction.startDate)")
-            }
 
             // Compute the target value as a function of time since the dose started
             let targetValue = targetGlucoseValue(

--- a/Sources/LoopAlgorithm/Insulin/InsulinMath.swift
+++ b/Sources/LoopAlgorithm/Insulin/InsulinMath.swift
@@ -399,7 +399,6 @@ extension Collection where Element == BasalRelativeDose {
 
         var lastDate = start
         var date = start
-        var effectSum: Double = 0
         var values = [GlucoseEffect]()
         let unit = HKUnit.milligramsPerDeciliter
 
@@ -412,6 +411,9 @@ extension Collection where Element == BasalRelativeDose {
 
                 // Sum effects over pertinent ISF timeline segments
                 let isfSegments = insulinSensitivityTimeline.filterDateRange(lastDate, date)
+                if isfSegments.count == 0 {
+                    preconditionFailure("ISF Timeline must cover dose absorption duration")
+                }
                 return value + isfSegments.reduce(0, { partialResult, segment in
                     let start = Swift.max(lastDate, segment.startDate)
                     let end = Swift.min(date, segment.endDate)
@@ -419,8 +421,7 @@ extension Collection where Element == BasalRelativeDose {
                 })
             }
 
-            effectSum += value
-            values.append(GlucoseEffect(startDate: date, quantity: HKQuantity(unit: unit, doubleValue: effectSum)))
+            values.append(GlucoseEffect(startDate: date, quantity: HKQuantity(unit: unit, doubleValue: value)))
             lastDate = date
             date = date.addingTimeInterval(delta)
         } while date <= end

--- a/Sources/LoopAlgorithm/Insulin/InsulinMath.swift
+++ b/Sources/LoopAlgorithm/Insulin/InsulinMath.swift
@@ -166,7 +166,88 @@ extension InsulinDose {
     }
 }
 
+public extension Array where Element == AbsoluteScheduleValue<Double> {
+    func trimmed(from start: Date? = nil, to end: Date? = nil) -> [AbsoluteScheduleValue<Double>] {
+        return self.compactMap { (entry) -> AbsoluteScheduleValue<Double>? in
+            if let start, entry.endDate < start {
+                return nil
+            }
+            if let end, entry.startDate > end {
+                return nil
+            }
+            return AbsoluteScheduleValue(
+                startDate: Swift.max(start ?? entry.startDate, entry.startDate),
+                endDate: Swift.min(end ??  entry.endDate, entry.endDate),
+                value: entry.value
+            )
+        }
+    }
+}
+
+
 extension Collection where Element: InsulinDose {
+
+    /// Returns an array of BasalRelativeDoses, based on annotating a sequence of dose entries with the given basal history.
+    ///
+    /// Doses which cross time boundaries in the basal rate schedule are split into multiple entries.
+    ///
+    /// - Parameter basalSchedule: A history of basal rates covering the timespan of these doses.
+    /// - Parameter fillBasalGaps: If true, the returned array will interpolate doses from basal schedule for those parts of the 
+    ///                             timeline that this array does not cover.
+    /// - Returns: An array of annotated dose entries
+    public func annotated(with basalHistory: [AbsoluteScheduleValue<Double>], fillBasalGaps: Bool = false) -> [BasalRelativeDose] {
+        var annotatedDoses: [BasalRelativeDose] = []
+
+        let basalAdjustments = self.filter { $0.deliveryType == .basal }
+
+        let date = [basalHistory.first?.startDate, basalAdjustments.first?.startDate].compactMap { $0 }.min()
+
+        if !fillBasalGaps {
+            guard self.count > 0 else {
+                return []
+            }
+        }
+
+        guard var date else {
+            return []
+        }
+
+        func fillGapWithBasal(start: Date, end: Date) -> [BasalRelativeDose] {
+            let basals = basalHistory.trimmed(from: start, to: end)
+            return basals.map { entry in
+                BasalRelativeDose(
+                    type: .basal(scheduledRate: entry.value),
+                    startDate: entry.startDate,
+                    endDate: entry.endDate,
+                    volume: entry.value * entry.duration.hours
+                )
+            }
+        }
+
+        for dose in self {
+            if dose.deliveryType != .basal {
+                annotatedDoses.append(BasalRelativeDose.fromBolus(dose: dose))
+                continue
+            }
+
+            if date < dose.startDate && fillBasalGaps {
+                // Fill date <-> dose.startDate gap with basal
+                annotatedDoses.append(contentsOf: fillGapWithBasal(start: date, end: dose.startDate))
+            }
+
+            let basalItems = basalHistory.filterDateRange(dose.startDate, dose.endDate)
+            annotatedDoses += dose.annotated(with: basalItems)
+            date = dose.endDate
+        }
+
+        let endDate = [basalHistory.last?.endDate, basalAdjustments.last?.endDate].compactMap { $0 }.max() ?? date
+
+        if date < endDate && fillBasalGaps {
+            annotatedDoses.append(contentsOf: fillGapWithBasal(start: date, end: endDate))
+        }
+
+        return annotatedDoses
+    }
 
     /// Annotates a sequence of dose entries with the configured basal history
     ///
@@ -188,6 +269,7 @@ extension Collection where Element: InsulinDose {
 
         return annotatedDoses
     }
+
 }
 
 extension Collection where Element == BasalRelativeDose {

--- a/Tests/LoopAlgorithmTests/InsulinMathTests.swift
+++ b/Tests/LoopAlgorithmTests/InsulinMathTests.swift
@@ -96,6 +96,44 @@ class InsulinMathTests: XCTestCase {
         }
     }
 
+    func testGlucoseEffectsHistory() {
+        let startDate = dateFormatter.date(from: "2015-10-15T00:00:00")!
+        func t(_ offset: TimeInterval) -> Date { return startDate.addingTimeInterval(offset) }
+
+        let doses: [BasalRelativeDose] = [
+            BasalRelativeDose(type: .bolus, startDate: t(.hours(1)), endDate: t(.hours(1.1)), volume: 5),
+            BasalRelativeDose(type: .bolus, startDate: t(.hours(2)), endDate: t(.hours(2.1)), volume: 5)
+        ]
+
+        let sensitivity: [AbsoluteScheduleValue<HKQuantity>] = [
+            AbsoluteScheduleValue(startDate: t(.hours(1)), endDate: t(.hours(8)), value: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 50))
+        ]
+
+        let effects = doses.glucoseEffects(insulinSensitivityHistory: sensitivity)
+
+        XCTAssertEqual(effects.count, 89)
+        XCTAssertEqual(effects.last!.quantity.doubleValue(for: .milligramsPerDeciliter), -500)
+    }
+
+    func testGlucoseEffectsTimeline() {
+        let startDate = dateFormatter.date(from: "2015-10-15T00:00:00")!
+        func t(_ offset: TimeInterval) -> Date { return startDate.addingTimeInterval(offset) }
+
+        let doses: [BasalRelativeDose] = [
+            BasalRelativeDose(type: .bolus, startDate: t(.hours(1)), endDate: t(.hours(1.1)), volume: 5),
+            BasalRelativeDose(type: .bolus, startDate: t(.hours(2)), endDate: t(.hours(2.1)), volume: 5)
+        ]
+
+        let sensitivity: [AbsoluteScheduleValue<HKQuantity>] = [
+            AbsoluteScheduleValue(startDate: t(.hours(1)), endDate: t(.hours(9)), value: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 50))
+        ]
+
+        let effects = doses.glucoseEffects(insulinSensitivityTimeline: sensitivity)
+
+        XCTAssertEqual(effects.count, 89)
+        XCTAssertEqual(effects.last!.quantity.doubleValue(for: .milligramsPerDeciliter), -500)
+    }
+
     func testGlucoseEffectFromShortTempBasal() {
         let startDate = dateFormatter.date(from: "2015-07-13T12:02:37")!
         let endDate = dateFormatter.date(from: "2015-07-13T12:07:37")!


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4858

Annotating basal for LoopAlgorithm generally does not need to fill caps, as effects from scheduled basal are 0, but other clients may want to infer the scheduled basal doses between, for calculating things like total delivery.