### PR TITLE
LOOP-4665 Add flag for enabling mid-absorption isf effects

### DIFF
--- a/Sources/LoopAlgorithm/AlgorithmInput.swift
+++ b/Sources/LoopAlgorithm/AlgorithmInput.swift
@@ -28,6 +28,7 @@ public protocol AlgorithmInput {
     var maxBasalRate: Double { get }
     var useIntegralRetrospectiveCorrection: Bool { get }
     var includePositiveVelocityAndRC: Bool { get }
+    var useMidAbsorptionISF: Bool { get }
     var carbAbsorptionModel: CarbAbsorptionModel { get }
     var recommendationInsulinModel: InsulinModel { get }
     var recommendationType: DoseRecommendationType { get }

--- a/Sources/LoopAlgorithm/AlgorithmInputFixture.swift
+++ b/Sources/LoopAlgorithm/AlgorithmInputFixture.swift
@@ -139,6 +139,9 @@ extension AlgorithmInputFixture: Codable {
         } else {
             self.recommendationType = .automaticBolus
         }
+
+        self.automaticBolusApplicationFactor = try container.decodeIfPresent(Double.self, forKey: .automaticBolusApplicationFactor)
+
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -171,7 +174,7 @@ extension AlgorithmInputFixture: Codable {
         try container.encode(useMidAbsorptionISF, forKey: .useMidAbsorptionISF)
         try container.encode(recommendationInsulinType.rawValue, forKey: .recommendationInsulinType)
         try container.encode(recommendationType.rawValue, forKey: .recommendationType)
-
+        try container.encode(automaticBolusApplicationFactor, forKey: .automaticBolusApplicationFactor)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -191,6 +194,7 @@ extension AlgorithmInputFixture: Codable {
         case useMidAbsorptionISF
         case recommendationInsulinType
         case recommendationType
+        case automaticBolusApplicationFactor
     }
 }
 

--- a/Sources/LoopAlgorithm/AlgorithmInputFixture.swift
+++ b/Sources/LoopAlgorithm/AlgorithmInputFixture.swift
@@ -29,6 +29,7 @@ public struct AlgorithmInputFixture: AlgorithmInput {
     public var maxBasalRate: Double
     public var useIntegralRetrospectiveCorrection: Bool
     public var includePositiveVelocityAndRC: Bool
+    public var useMidAbsorptionISF: Bool
     public var carbAbsorptionModel: CarbAbsorptionModel = .piecewiseLinear
     public var recommendationInsulinType: FixtureInsulinType = .novolog
     public var recommendationType: DoseRecommendationType = .automaticBolus
@@ -64,6 +65,7 @@ public struct AlgorithmInputFixture: AlgorithmInput {
         maxBolus: Double,
         maxBasalRate: Double,
         useIntegralRetrospectiveCorrection: Bool = false,
+        useMidAbsorptionISF: Bool = false,
         includePositiveVelocityAndRC: Bool = true,
         carbAbsorptionModel: CarbAbsorptionModel = .piecewiseLinear,
         recommendationInsulinType: FixtureInsulinType,
@@ -83,6 +85,7 @@ public struct AlgorithmInputFixture: AlgorithmInput {
         self.maxBasalRate = maxBasalRate
         self.useIntegralRetrospectiveCorrection = useIntegralRetrospectiveCorrection
         self.includePositiveVelocityAndRC = includePositiveVelocityAndRC
+        self.useMidAbsorptionISF = useMidAbsorptionISF
         self.carbAbsorptionModel = carbAbsorptionModel
         self.recommendationInsulinType = recommendationInsulinType
         self.recommendationType = recommendationType
@@ -117,6 +120,7 @@ extension AlgorithmInputFixture: Codable {
         self.maxBasalRate = try container.decode(Double.self, forKey: .maxBasalRate)
         self.useIntegralRetrospectiveCorrection = try container.decodeIfPresent(Bool.self, forKey: .useIntegralRetrospectiveCorrection) ?? false
         self.includePositiveVelocityAndRC = try container.decodeIfPresent(Bool.self, forKey: .includePositiveVelocityAndRC) ?? true
+        self.useMidAbsorptionISF = try container.decodeIfPresent(Bool.self, forKey: .useMidAbsorptionISF) ?? false
 
         if let rawRecommendationInsulinType = try container.decodeIfPresent(String.self, forKey: .recommendationInsulinType) {
             guard let decodedRecommendationInsulinType = FixtureInsulinType(rawValue: rawRecommendationInsulinType) else {
@@ -164,6 +168,7 @@ extension AlgorithmInputFixture: Codable {
         if !includePositiveVelocityAndRC {
             try container.encode(includePositiveVelocityAndRC, forKey: .includePositiveVelocityAndRC)
         }
+        try container.encode(useMidAbsorptionISF, forKey: .useMidAbsorptionISF)
         try container.encode(recommendationInsulinType.rawValue, forKey: .recommendationInsulinType)
         try container.encode(recommendationType.rawValue, forKey: .recommendationType)
 
@@ -183,6 +188,7 @@ extension AlgorithmInputFixture: Codable {
         case maxBasalRate
         case useIntegralRetrospectiveCorrection
         case includePositiveVelocityAndRC
+        case useMidAbsorptionISF
         case recommendationInsulinType
         case recommendationType
     }

--- a/Sources/LoopAlgorithm/LoopAlgorithm.swift
+++ b/Sources/LoopAlgorithm/LoopAlgorithm.swift
@@ -161,6 +161,7 @@ public struct LoopAlgorithm {
         algorithmEffectsOptions: AlgorithmEffectsOptions = .all,
         useIntegralRetrospectiveCorrection: Bool = false,
         includingPositiveVelocityAndRC: Bool = true,
+        useMidAbsorptionISF: Bool = false,
         carbAbsorptionModel: CarbAbsorptionComputable = PiecewiseLinearAbsorption()
     ) -> LoopPrediction<CarbType> where CarbType: CarbEntry, GlucoseType: GlucoseSampleValue, InsulinDoseType: InsulinDose {
 
@@ -209,10 +210,17 @@ public struct LoopAlgorithm {
                 maxDate = glucoseEnd
             }
 
-            insulinEffects = dosesRelativeToBasal.glucoseEffects(
-                insulinSensitivityHistory: sensitivity,
-                from: minDate,
-                to: maxDate)
+            if useMidAbsorptionISF {
+                insulinEffects = dosesRelativeToBasal.glucoseEffectsMidAbsorptionISF(
+                    insulinSensitivityHistory: sensitivity,
+                    from: minDate,
+                    to: maxDate)
+            } else {
+                insulinEffects = dosesRelativeToBasal.glucoseEffects(
+                    insulinSensitivityHistory: sensitivity,
+                    from: minDate,
+                    to: maxDate)
+            }
 
             // ICE
             insulinCounteractionEffects = glucoseHistory.counteractionEffects(to: insulinEffects)
@@ -469,6 +477,7 @@ public struct LoopAlgorithm {
             algorithmEffectsOptions: .all,
             useIntegralRetrospectiveCorrection: input.useIntegralRetrospectiveCorrection,
             includingPositiveVelocityAndRC: input.includePositiveVelocityAndRC,
+            useMidAbsorptionISF: input.useMidAbsorptionISF,
             carbAbsorptionModel: input.carbAbsorptionModel.model
         )
 

--- a/Tests/LoopAlgorithmTests/InsulinMathTests.swift
+++ b/Tests/LoopAlgorithmTests/InsulinMathTests.swift
@@ -115,7 +115,7 @@ class InsulinMathTests: XCTestCase {
         XCTAssertEqual(effects.last!.quantity.doubleValue(for: .milligramsPerDeciliter), -500)
     }
 
-    func testGlucoseEffectsTimeline() {
+    func testGlucoseEffectsMidAbsorptionISFTimeline() {
         let startDate = dateFormatter.date(from: "2015-10-15T00:00:00")!
         func t(_ offset: TimeInterval) -> Date { return startDate.addingTimeInterval(offset) }
 
@@ -128,10 +128,10 @@ class InsulinMathTests: XCTestCase {
             AbsoluteScheduleValue(startDate: t(.hours(1)), endDate: t(.hours(9)), value: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 50))
         ]
 
-        let effects = doses.glucoseEffects(insulinSensitivityTimeline: sensitivity)
+        let effects = doses.glucoseEffectsMidAbsorptionISF(insulinSensitivityHistory: sensitivity)
 
         XCTAssertEqual(effects.count, 89)
-        XCTAssertEqual(effects.last!.quantity.doubleValue(for: .milligramsPerDeciliter), -500)
+        XCTAssertEqual(effects.last!.quantity.doubleValue(for: .milligramsPerDeciliter), -500, accuracy: 0.5)
     }
 
     func testGlucoseEffectFromShortTempBasal() {

--- a/Tests/LoopAlgorithmTests/Mocks/LoopAlgorithmInputMock.swift
+++ b/Tests/LoopAlgorithmTests/Mocks/LoopAlgorithmInputMock.swift
@@ -10,7 +10,7 @@ import HealthKit
 @testable import LoopAlgorithm
 
 extension AlgorithmInputFixture {
-    /// Mocks stable, in range glucose, no insulin, no carbs, with reasonable settings
+    /// Mocks rising glucose, no insulin, no carbs, with reasonable settings
     static func mock(for now: Date = Date()) -> AlgorithmInputFixture {
 
         func d(_ interval: TimeInterval) -> Date {


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4665

Adds a flag, `useMidAbsorptionISF` to the input for the algorithm. It defaults to false. If enabled, the ISF part of how glucose are calculated from an insulin dose can vary over the absorption time of the dose. Otherwise, the ISF in effect at the start time is used for the all of the dose effects.

Also fixes a bug in how dose effects are calculated for "continuous delivery" doses when the flag is enabled.

Also added a quick fix for allowing the automaticBolusApplicationFactor to be set via json file; it was previously an option for the algorithm, just not exposed via json parsing.