### PR TITLE
LOOP-5233 Mark AbsoluteScheduleValue as sendable type

### DIFF
--- a/Sources/LoopAlgorithm/AbsoluteScheduleValue.swift
+++ b/Sources/LoopAlgorithm/AbsoluteScheduleValue.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public struct AbsoluteScheduleValue<T>: TimelineValue {
+public struct AbsoluteScheduleValue<T: Sendable>: TimelineValue, Sendable {
     public var startDate: Date
     public var endDate: Date
     public var value: T


### PR DESCRIPTION
This is to help SettingsManager conform to mainactor protocols.