### PR TITLE
Fix issue with mid-absorption isf calculation

### DIFF
--- a/Sources/LoopAlgorithm/AlgorithmInputFixture.swift
+++ b/Sources/LoopAlgorithm/AlgorithmInputFixture.swift
@@ -197,3 +197,62 @@ extension AlgorithmInputFixture: Codable {
     }
 }
 
+extension AlgorithmInputFixture {
+    static public func printFixture(_ input: any AlgorithmInput) {
+        let fixture = AlgorithmInputFixture(
+            predictionStart: input.predictionStart,
+            glucoseHistory: input.glucoseHistory.map(\.asFixtureGlucoseSample),
+            doses: input.doses.map(\.asFixtureInsulinDose),
+            carbEntries: input.carbEntries.map(\.asFixtureCarbEntry),
+            basal: input.basal,
+            sensitivity: input.sensitivity,
+            carbRatio: input.carbRatio,
+            target: input.target,
+            suspendThreshold: input.suspendThreshold,
+            maxBolus: input.maxBolus,
+            maxBasalRate: input.maxBasalRate,
+            useIntegralRetrospectiveCorrection: input.useIntegralRetrospectiveCorrection,
+            useMidAbsorptionISF: input.useMidAbsorptionISF,
+            includePositiveVelocityAndRC: input.includePositiveVelocityAndRC,
+            carbAbsorptionModel: input.carbAbsorptionModel,
+            recommendationInsulinType: .novolog,
+            recommendationType: input.recommendationType,
+            automaticBolusApplicationFactor: input.automaticBolusApplicationFactor
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+
+        do {
+            let encoded = try encoder.encode(fixture)
+            print(String(data: encoded , encoding: .utf8)!)
+        } catch {
+            print("Error encoding fixture: \(error)")
+        }
+    }
+}
+
+extension GlucoseSampleValue {
+    var asFixtureGlucoseSample: FixtureGlucoseSample {
+        return .init(startDate: startDate, quantity: quantity)
+    }
+}
+
+extension InsulinDose {
+    var asFixtureInsulinDose: FixtureInsulinDose {
+        return .init(deliveryType: deliveryType, startDate: startDate, endDate: endDate, volume: volume)
+    }
+}
+
+extension CarbEntry {
+    var asFixtureCarbEntry: FixtureCarbEntry {
+        return FixtureCarbEntry(
+            absorptionTime: absorptionTime,
+            startDate: startDate,
+            quantity: quantity,
+            foodType: nil
+        )
+    }
+}
+

--- a/Sources/LoopAlgorithm/Carbs/FixtureCarbEntry.swift
+++ b/Sources/LoopAlgorithm/Carbs/FixtureCarbEntry.swift
@@ -12,6 +12,18 @@ public struct FixtureCarbEntry: CarbEntry {
     public var startDate: Date
     public var quantity: LoopQuantity
     public var foodType: String?
+
+    public init(
+        absorptionTime: TimeInterval? = nil,
+        startDate: Date,
+        quantity: LoopQuantity,
+        foodType: String? = nil
+    ) {
+        self.absorptionTime = absorptionTime
+        self.startDate = startDate
+        self.quantity = quantity
+        self.foodType = foodType
+    }
 }
 
 extension FixtureCarbEntry: Codable {

--- a/Sources/LoopAlgorithm/Insulin/DoseMath.swift
+++ b/Sources/LoopAlgorithm/Insulin/DoseMath.swift
@@ -232,7 +232,7 @@ extension Array where Element: GlucoseValue {
                 let end = Swift.min(prediction.startDate, segment.endDate).timeIntervalSince(date)
                 let percentEffected = model.percentEffectRemaining(at: start) - model.percentEffectRemaining(at: end)
                 isfEnd = end
-                return percentEffected * segment.value.doubleValue(for: unit)
+                return partialResult + percentEffected * segment.value.doubleValue(for: unit)
             }
 
             guard let isfEnd, isfEnd >= prediction.startDate.timeIntervalSince(date) else {

--- a/Tests/LoopAlgorithmTests/Fixtures/meal-bolus.json
+++ b/Tests/LoopAlgorithmTests/Fixtures/meal-bolus.json
@@ -1,0 +1,192 @@
+{
+  "automaticBolusApplicationFactor" : 0.4,
+  "basal" : [
+    {
+      "endDate" : "2025-07-29T05:00:00Z",
+      "startDate" : "2025-07-28T20:00:00Z",
+      "value" : 0.85
+    },
+    {
+      "endDate" : "2025-07-29T14:49:56Z",
+      "startDate" : "2025-07-29T05:00:00Z",
+      "value" : 1
+    },
+    {
+      "endDate" : "2025-07-29T16:12:36Z",
+      "startDate" : "2025-07-29T14:49:56Z",
+      "value" : 1
+    },
+    {
+      "endDate" : "2025-07-29T16:12:44Z",
+      "startDate" : "2025-07-29T16:12:36Z",
+      "value" : 1
+    },
+    {
+      "endDate" : "2025-07-29T16:39:30Z",
+      "startDate" : "2025-07-29T16:12:44Z",
+      "value" : 1
+    }
+  ],
+  "carbEntries" : [
+    {
+      "absorptionTime" : 10800,
+      "date" : "2025-07-29T16:12:48Z",
+      "grams" : 20
+    }
+  ],
+  "carbRatio" : [
+    {
+      "endDate" : "2025-07-29T05:00:00Z",
+      "startDate" : "2025-07-29T04:11:52Z",
+      "value" : 10
+    },
+    {
+      "endDate" : "2025-07-29T14:49:56Z",
+      "startDate" : "2025-07-29T05:00:00Z",
+      "value" : 10
+    },
+    {
+      "endDate" : "2025-07-29T16:12:36Z",
+      "startDate" : "2025-07-29T14:49:56Z",
+      "value" : 10
+    },
+    {
+      "endDate" : "2025-07-29T16:12:44Z",
+      "startDate" : "2025-07-29T16:12:36Z",
+      "value" : 10
+    },
+    {
+      "endDate" : "2025-07-29T18:12:44Z",
+      "startDate" : "2025-07-29T16:12:44Z",
+      "value" : 10
+    },
+    {
+      "endDate" : "2025-07-29T22:25:00Z",
+      "startDate" : "2025-07-29T18:12:44Z",
+      "value" : 10
+    }
+  ],
+  "doses" : [
+    {
+      "endDate" : "2025-07-29T05:00:00Z",
+      "startDate" : "2025-07-28T20:00:00Z",
+      "type" : "basal",
+      "volume" : 7.65
+    },
+    {
+      "endDate" : "2025-07-29T14:49:01Z",
+      "startDate" : "2025-07-29T05:00:00Z",
+      "type" : "basal",
+      "volume" : 9.8
+    },
+    {
+      "endDate" : "2025-07-29T15:07:36Z",
+      "startDate" : "2025-07-29T14:49:01Z",
+      "type" : "basal",
+      "volume" : 0.3
+    },
+    {
+      "endDate" : "2025-07-29T15:57:58Z",
+      "startDate" : "2025-07-29T15:07:36Z",
+      "type" : "basal",
+      "volume" : 0.85
+    },
+    {
+      "endDate" : "2025-07-29T16:01:05Z",
+      "startDate" : "2025-07-29T15:57:58Z",
+      "type" : "basal",
+      "volume" : 0.05
+    },
+    {
+      "endDate" : "2025-07-29T16:07:02Z",
+      "startDate" : "2025-07-29T16:01:05Z",
+      "type" : "basal",
+      "volume" : 0.1
+    },
+    {
+      "endDate" : "2025-07-29T16:09:30Z",
+      "startDate" : "2025-07-29T16:07:02Z",
+      "type" : "basal",
+      "volume" : 0.04098938193586137
+    },
+    {
+      "endDate" : "2025-07-29T16:39:30Z",
+      "startDate" : "2025-07-29T16:09:30Z",
+      "type" : "basal",
+      "volume" : 0
+    }
+  ],
+  "glucoseHistory" : [
+    {
+      "date" : "2025-07-29T14:49:01Z",
+      "value" : 110
+    },
+    {
+      "date" : "2025-07-29T14:54:01Z",
+      "value" : 112
+    },
+    {
+      "date" : "2025-07-29T14:59:01Z",
+      "value" : 113
+    },
+    {
+      "date" : "2025-07-29T15:04:37Z",
+      "value" : 115
+    },
+    {
+      "date" : "2025-07-29T15:07:36Z",
+      "value" : 116
+    },
+    {
+      "date" : "2025-07-29T15:14:11Z",
+      "value" : 119
+    },
+    {
+      "date" : "2025-07-29T15:57:58Z",
+      "value" : 129
+    },
+    {
+      "date" : "2025-07-29T16:01:05Z",
+      "value" : 129
+    },
+    {
+      "date" : "2025-07-29T16:06:05Z",
+      "value" : 129
+    },
+    {
+      "date" : "2025-07-29T16:07:02Z",
+      "value" : 130
+    },
+    {
+      "date" : "2025-07-29T16:09:30Z",
+      "value" : 130
+    }
+  ],
+  "maxBasalRate" : 5,
+  "maxBolus" : 10,
+  "predictionStart" : "2025-07-29T16:12:52Z",
+  "recommendationInsulinType" : "novolog",
+  "recommendationType" : "manualBolus",
+  "sensitivity" : [
+    {
+      "endDate" : "2025-07-29T16:30:00Z",
+      "startDate" : "2025-07-28T20:00:00Z",
+      "value" : 55
+    },
+    {
+      "endDate" : "2025-07-29T22:50:00Z",
+      "startDate" : "2025-07-29T16:30:00Z",
+      "value" : 65
+    }
+  ],
+  "suspendThreshold" : 75,
+  "target" : [
+    {
+      "endDate" : "2025-07-29T22:25:00Z",
+      "lowerBound" : 140,
+      "startDate" : "2025-07-29T16:12:44Z",
+      "upperBound" : 160
+    }
+  ],
+  "useMidAbsorptionISF" : true
+}


### PR DESCRIPTION
The math for adding up ISF factors over the absorption of a dose was not accumulating correctly, which would lead to overestimations of needed insulin.