### PR TITLE
LOOP-5235 Fix decoding of old AutomaticDoseRecommendation structures 

### DIFF
--- a/Sources/LoopAlgorithm/AutomaticDoseRecommendation.swift
+++ b/Sources/LoopAlgorithm/AutomaticDoseRecommendation.swift
@@ -38,4 +38,12 @@ public struct AutomaticDoseRecommendation: Equatable {
     }
 }
 
-extension AutomaticDoseRecommendation: Codable {}
+extension AutomaticDoseRecommendation: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Provide default TempBasalRecommendation if basalAdjustment is missing
+        self.basalAdjustment = try container.decodeIfPresent(TempBasalRecommendation.self, forKey: .basalAdjustment) ?? TempBasalRecommendation(unitsPerHour: 0, duration: 0)
+        self.bolusUnits = try container.decodeIfPresent(Double.self, forKey: .bolusUnits)
+        self.direction = try container.decode(Direction.self, forKey: .direction)
+    }
+}

--- a/Sources/LoopAlgorithm/Insulin/InsulinMath.swift
+++ b/Sources/LoopAlgorithm/Insulin/InsulinMath.swift
@@ -418,8 +418,12 @@ extension Collection where Element == BasalRelativeDose {
                 return value + isfSegments.reduce(0, { partialResult, segment in
                     let start = Swift.max(lastDate, segment.startDate)
                     let end = Swift.min(date, segment.endDate)
-                    let effect = dose.glucoseEffect(during: DateInterval(start: start, end: end), insulinSensitivity: segment.value.doubleValue(for: unit), delta: delta)
-                    return partialResult + effect
+                    if start != end {
+                        let effect = dose.glucoseEffect(during: DateInterval(start: start, end: end), insulinSensitivity: segment.value.doubleValue(for: unit), delta: delta)
+                        return partialResult + effect
+                    } else {
+                        return partialResult
+                    }
                 })
             }
 


### PR DESCRIPTION
* Fix decoding of old AutomaticDoseRecommendation structures without basalAdjustment,
* Optimize dose effect calc, when periods are 0 duration. No functional change; just saving compute.