### PR TITLE
Add asymmetric momentum + hybrid asymmetric momentum effect

### DIFF
--- a/Sources/LoopAlgorithm/Glucose/GlucoseMath.swift
+++ b/Sources/LoopAlgorithm/Glucose/GlucoseMath.swift
@@ -220,6 +220,70 @@ extension BidirectionalCollection where Element: GlucoseSampleValue, Index == In
         return values
     }
 
+    /// Hybrid momentum: standard linear regression on rises/steady, fast EMA on drops.
+    ///
+    /// Designed to keep positive-direction response identical to normal Loop's
+    /// `linearMomentumEffect` while reacting quickly when the latest instantaneous
+    /// velocity falls below the regression-implied slope (momentum is dropping).
+    ///
+    /// - Parameters:
+    ///   - alphaFast: Mixing weight on latest instantV when momentum is dropping
+    ///                (1.0 = use latest only; 0 = ignore drop). Default 0.85.
+    public func hybridAsymmetricMomentumEffect(
+        duration: TimeInterval = GlucoseMath.momentumDuration,
+        delta: TimeInterval = GlucoseMath.defaultDelta,
+        velocityMaximum: LoopQuantity? = nil,
+        alphaFast: Double = 0.85
+    ) -> [GlucoseEffect] {
+
+        let velocityMax = velocityMaximum ?? LoopQuantity(unit: .milligramsPerDeciliterPerMinute, doubleValue: 4.0)
+
+        guard
+            self.count > 2,
+            hasGradualTransitions() && isContinuous() && !containsCalibrations() && hasSingleProvenance,
+            let firstSample = self.first,
+            let lastSample = self.last,
+            let (startDate, endDate) = LoopMath.simulationDateRangeForSamples([lastSample], duration: duration, delta: delta)
+        else {
+            return []
+        }
+
+        let unit = LoopUnit.milligramsPerDeciliter
+        let sorted = self.sorted { $0.startDate < $1.startDate }
+
+        let (slope: regressionSlope, intercept: _) = sorted.map { (
+            x: $0.startDate.timeIntervalSince(firstSample.startDate),
+            y: $0.quantity.doubleValue(for: unit)
+        ) }.linearRegression()
+
+        guard regressionSlope.isFinite, sorted.count >= 2 else { return [] }
+
+        let n = sorted.count
+        let dtLast = sorted[n - 1].startDate.timeIntervalSince(sorted[n - 2].startDate)
+        guard dtLast > 0 else { return [] }
+        let latestInstantV = (sorted[n - 1].quantity.doubleValue(for: unit)
+                              - sorted[n - 2].quantity.doubleValue(for: unit)) / dtLast
+
+        let chosenSlope: Double
+        if latestInstantV < regressionSlope {
+            chosenSlope = alphaFast * latestInstantV + (1.0 - alphaFast) * regressionSlope
+        } else {
+            chosenSlope = regressionSlope
+        }
+
+        let limitedSlope = Swift.min(chosenSlope, velocityMax.doubleValue(for: .milligramsPerDeciliterPerSecond))
+
+        var date = startDate
+        var values = [GlucoseEffect]()
+        repeat {
+            let value = Swift.max(0, date.timeIntervalSince(lastSample.startDate)) * limitedSlope
+            values.append(GlucoseEffect(startDate: date, quantity: LoopQuantity(unit: unit, doubleValue: value)))
+            date = date.addingTimeInterval(delta)
+        } while date <= endDate
+
+        return values
+    }
+
 }
 
 

--- a/Sources/LoopAlgorithm/Glucose/GlucoseMath.swift
+++ b/Sources/LoopAlgorithm/Glucose/GlucoseMath.swift
@@ -153,6 +153,73 @@ extension BidirectionalCollection where Element: GlucoseSampleValue, Index == In
 
         return values
     }
+
+    /// Computes a momentum effect using an asymmetric EMA on instantaneous velocity.
+    ///
+    /// Builds positive momentum slowly (using `alphaSlow`) and sheds it quickly
+    /// whenever a single reading shows a velocity drop (using `alphaFast`).
+    /// This makes the algorithm conservative about assuming BG will keep rising,
+    /// while responding immediately to any signal that it is levelling off or falling.
+    ///
+    /// - Parameters:
+    ///   - duration: Projection duration. Default: `momentumDuration`.
+    ///   - delta: Time step for projected effects. Default: `defaultDelta`.
+    ///   - velocityMaximum: Hard cap on velocity. Default: 4 mg/dL/min.
+    ///   - alphaSlow: EMA weight when velocity is rising (0–1). Default: 0.15.
+    ///   - alphaFast: EMA weight when velocity is falling (0–1). Default: 0.85.
+    /// - Returns: An array of projected glucose effects.
+    public func asymmetricMomentumEffect(
+        duration: TimeInterval = GlucoseMath.momentumDuration,
+        delta: TimeInterval = GlucoseMath.defaultDelta,
+        velocityMaximum: LoopQuantity? = nil,
+        alphaSlow: Double = 0.15,
+        alphaFast: Double = 0.85
+    ) -> [GlucoseEffect] {
+
+        let velocityMax = velocityMaximum ?? LoopQuantity(unit: .milligramsPerDeciliterPerMinute, doubleValue: 4.0)
+
+        guard
+            self.count > 2,
+            hasGradualTransitions() && isContinuous() && !containsCalibrations() && hasSingleProvenance,
+            let lastSample = self.last,
+            let (startDate, endDate) = LoopMath.simulationDateRangeForSamples([lastSample], duration: duration, delta: delta)
+        else {
+            return []
+        }
+
+        let unit = LoopUnit.milligramsPerDeciliter
+        let sorted = self.sorted { $0.startDate < $1.startDate }
+
+        // Build asymmetric EMA over instantaneous velocities (mg/dL/sec)
+        var smoothed: Double? = nil
+        for i in 1 ..< sorted.count {
+            let dt = sorted[i].startDate.timeIntervalSince(sorted[i - 1].startDate)
+            guard dt > 0 else { continue }
+            let instantV = (sorted[i].quantity.doubleValue(for: unit)
+                            - sorted[i - 1].quantity.doubleValue(for: unit)) / dt
+            if let prev = smoothed {
+                let alpha = instantV < prev ? alphaFast : alphaSlow
+                smoothed = alpha * instantV + (1.0 - alpha) * prev
+            } else {
+                smoothed = instantV
+            }
+        }
+
+        guard let velocity = smoothed, velocity.isFinite else { return [] }
+
+        let cappedVelocity = Swift.min(velocity, velocityMax.doubleValue(for: .milligramsPerDeciliterPerSecond))
+
+        var date = startDate
+        var values = [GlucoseEffect]()
+        repeat {
+            let value = Swift.max(0, date.timeIntervalSince(lastSample.startDate)) * cappedVelocity
+            values.append(GlucoseEffect(startDate: date, quantity: LoopQuantity(unit: unit, doubleValue: value)))
+            date = date.addingTimeInterval(delta)
+        } while date <= endDate
+
+        return values
+    }
+
 }
 
 

--- a/Sources/LoopAlgorithm/LoopAlgorithm.swift
+++ b/Sources/LoopAlgorithm/LoopAlgorithm.swift
@@ -182,6 +182,7 @@ public struct LoopAlgorithm {
         gradualTransitionsThreshold: Double? = 40.0,
         momentumVelocityMaximum: LoopQuantity? = nil,
         useAsymmetricMomentum: Bool = false,
+        useHybridAsymmetricMomentum: Bool = false,
         momentumAlphaSlow: Double = 0.15,
         momentumAlphaFast: Double = 0.85
     ) -> LoopPrediction<CarbType> where CarbType: CarbEntry, GlucoseType: GlucoseSampleValue, InsulinDoseType: InsulinDose {
@@ -315,9 +316,13 @@ public struct LoopAlgorithm {
             var useMomentum: Bool = true
             if algorithmEffectsOptions.contains(.momentum) {
                 let momentumInputData = glucoseHistory.filterDateRange(start.addingTimeInterval(-GlucoseMath.momentumDataInterval), start)
-                momentumEffects = useAsymmetricMomentum
-                    ? momentumInputData.asymmetricMomentumEffect(velocityMaximum: momentumVelocityMaximum, alphaSlow: momentumAlphaSlow, alphaFast: momentumAlphaFast)
-                    : momentumInputData.linearMomentumEffect(velocityMaximum: momentumVelocityMaximum)
+                if useHybridAsymmetricMomentum {
+                    momentumEffects = momentumInputData.hybridAsymmetricMomentumEffect(velocityMaximum: momentumVelocityMaximum, alphaFast: momentumAlphaFast)
+                } else if useAsymmetricMomentum {
+                    momentumEffects = momentumInputData.asymmetricMomentumEffect(velocityMaximum: momentumVelocityMaximum, alphaSlow: momentumAlphaSlow, alphaFast: momentumAlphaFast)
+                } else {
+                    momentumEffects = momentumInputData.linearMomentumEffect(velocityMaximum: momentumVelocityMaximum)
+                }
                 if !includingPositiveVelocityAndRC, let netMomentum = momentumEffects.netEffect(), netMomentum.quantity.doubleValue(for: .milligramsPerDeciliter) > 0 {
                     // positive momentum is turned off
                     useMomentum = false

--- a/Sources/LoopAlgorithm/LoopAlgorithm.swift
+++ b/Sources/LoopAlgorithm/LoopAlgorithm.swift
@@ -179,7 +179,11 @@ public struct LoopAlgorithm {
         includingPositiveVelocityAndRC: Bool = true,
         useMidAbsorptionISF: Bool = false,
         carbAbsorptionModel: CarbAbsorptionComputable = PiecewiseLinearAbsorption(),
-        gradualTransitionsThreshold: Double? = 40.0
+        gradualTransitionsThreshold: Double? = 40.0,
+        momentumVelocityMaximum: LoopQuantity? = nil,
+        useAsymmetricMomentum: Bool = false,
+        momentumAlphaSlow: Double = 0.15,
+        momentumAlphaFast: Double = 0.85
     ) -> LoopPrediction<CarbType> where CarbType: CarbEntry, GlucoseType: GlucoseSampleValue, InsulinDoseType: InsulinDose {
 
         var prediction: [PredictedGlucoseValue] = []
@@ -311,7 +315,9 @@ public struct LoopAlgorithm {
             var useMomentum: Bool = true
             if algorithmEffectsOptions.contains(.momentum) {
                 let momentumInputData = glucoseHistory.filterDateRange(start.addingTimeInterval(-GlucoseMath.momentumDataInterval), start)
-                momentumEffects = momentumInputData.linearMomentumEffect()
+                momentumEffects = useAsymmetricMomentum
+                    ? momentumInputData.asymmetricMomentumEffect(velocityMaximum: momentumVelocityMaximum, alphaSlow: momentumAlphaSlow, alphaFast: momentumAlphaFast)
+                    : momentumInputData.linearMomentumEffect(velocityMaximum: momentumVelocityMaximum)
                 if !includingPositiveVelocityAndRC, let netMomentum = momentumEffects.netEffect(), netMomentum.quantity.doubleValue(for: .milligramsPerDeciliter) > 0 {
                     // positive momentum is turned off
                     useMomentum = false

--- a/Tests/LoopAlgorithmTests/AsymmetricMomentumTests.swift
+++ b/Tests/LoopAlgorithmTests/AsymmetricMomentumTests.swift
@@ -1,0 +1,182 @@
+//
+//  AsymmetricMomentumTests.swift
+//  LoopAlgorithm
+//
+//  Tests for asymmetricMomentumEffect and hybridAsymmetricMomentumEffect.
+//
+
+import XCTest
+@testable import LoopAlgorithm
+
+final class AsymmetricMomentumTests: XCTestCase {
+
+    private let unit = LoopUnit.milligramsPerDeciliter
+
+    /// Build a synthetic 5-min glucose timeline starting at `start` with the
+    /// given values. Default 5-min spacing matches CGM cadence.
+    private func samples(_ values: [Double], startingAt start: Date = Date(),
+                         spacing: TimeInterval = 5 * 60) -> [GlucoseFixtureValue] {
+        return values.enumerated().map { i, v in
+            GlucoseFixtureValue(
+                startDate: start.addingTimeInterval(TimeInterval(i) * spacing),
+                quantity: LoopQuantity(unit: unit, doubleValue: v),
+                isDisplayOnly: false,
+                wasUserEntered: false,
+                provenanceIdentifier: "test",
+                condition: nil,
+                trendRate: nil
+            )
+        }
+    }
+
+    // MARK: - Asymmetric momentum
+
+    func testAsymmetricReturnsEmptyOnTooFewSamples() {
+        let input = samples([100, 105])  // only 2 samples
+        let effects = input.asymmetricMomentumEffect()
+        XCTAssertTrue(effects.isEmpty, "Need > 2 samples; got \(effects.count) effects")
+    }
+
+    func testAsymmetricVelocityCapClamps() {
+        // Strongly rising: 100 → 200 over 25 min = +4 mg/dL/min sustained.
+        // With cap at 1.0 mg/dL/min, projected effect should be bounded by
+        // 1.0 × (projected_seconds) at the largest projected horizon.
+        let input = samples([100, 120, 140, 160, 180, 200])
+        let cap = LoopQuantity(unit: .milligramsPerDeciliterPerMinute, doubleValue: 1.0)
+        let effects = input.asymmetricMomentumEffect(velocityMaximum: cap)
+        XCTAssertFalse(effects.isEmpty)
+        // Last sample is at index 5 → +25 min from start
+        // After velocity cap, the largest projected value over 30 min should
+        // not exceed 1.0 mg/dL/min × 30 min = 30 mg/dL.
+        let lastValue = effects.last!.quantity.doubleValue(for: unit)
+        XCTAssertLessThanOrEqual(lastValue, 30.0 + 1e-6,
+            "Capped velocity should bound the last projected effect")
+    }
+
+    func testAsymmetricBuildsSlowlyOnRise() {
+        // Steady rise. The EMA-on-rise uses alphaSlow=0.15, so the
+        // smoothed velocity should be SMALLER than the instantaneous velocity.
+        // Build: start with a low-velocity, then accelerate. Slow EMA should
+        // lag the acceleration, so projected effect < (instantaneous slope × time).
+        // 100, 102, 104, 110, 120, 130 — accelerating rise
+        let input = samples([100, 102, 104, 110, 120, 130])
+        let effects = input.asymmetricMomentumEffect(
+            velocityMaximum: LoopQuantity(unit: .milligramsPerDeciliterPerMinute, doubleValue: 100), // effectively uncapped
+            alphaSlow: 0.15,
+            alphaFast: 0.85
+        )
+        XCTAssertFalse(effects.isEmpty)
+        // Instantaneous velocity of the last interval (120 → 130 over 5 min) = +2 mg/dL/min.
+        // EMA-slow should produce a smoothed velocity well below that.
+        // At 30 min projection: effect should be < 2 mg/dL/min × 30 min = 60.
+        let lastValue = effects.last!.quantity.doubleValue(for: unit)
+        XCTAssertLessThan(lastValue, 60.0,
+            "Slow alpha should suppress the latest acceleration; last effect was \(lastValue)")
+    }
+
+    func testAsymmetricRespondsQuicklyOnDrop() {
+        // Rise then sharp drop. With alphaFast=0.85 on falling instantV,
+        // the smoothed velocity should drop quickly to reflect the latest decline.
+        // 100, 110, 120, 125, 120, 110 — rise then drop
+        let input = samples([100, 110, 120, 125, 120, 110])
+        let effects = input.asymmetricMomentumEffect(
+            velocityMaximum: LoopQuantity(unit: .milligramsPerDeciliterPerMinute, doubleValue: 100),
+            alphaSlow: 0.15,
+            alphaFast: 0.85
+        )
+        XCTAssertFalse(effects.isEmpty)
+        // Last instantV (120 → 110 over 5 min) = -2 mg/dL/min.
+        // With alphaFast=0.85, smoothed velocity should be much closer to -2
+        // than to the prior smoothed (which built slowly).
+        // Velocity is then clamped to min(v, velocityMax), which only caps positive.
+        // Effect at any projected time = (time_from_lastSample) × smoothedVel,
+        // clamped at lower bound 0 via Swift.max(0, time_from_lastSample) — so
+        // negative velocity over time-since-last gives 0 or below. Actually the
+        // formula in code is Swift.max(0, date.timeIntervalSince(lastSample))
+        // × cappedVelocity, so at date == lastSample.startDate, effect=0.
+        // For dates after lastSample, time_from_lastSample > 0 and velocity is
+        // negative → effect < 0.
+        let firstEffectAfterLast = effects.first { $0.startDate > input.last!.startDate }
+        XCTAssertNotNil(firstEffectAfterLast)
+        let v = firstEffectAfterLast!.quantity.doubleValue(for: unit)
+        XCTAssertLessThan(v, 0,
+            "After a drop, projected effect should be negative (reflecting BG falling)")
+    }
+
+    func testAsymmetricAlphaEqualBehavesLikeSimpleEMA() {
+        // With alphaSlow == alphaFast, the asymmetric switch becomes a no-op
+        // and we get a simple EMA. Sanity-check that the output is finite and
+        // doesn't differ for two equal alphas of different values.
+        let input = samples([100, 105, 110, 115, 120])
+        let effectsA = input.asymmetricMomentumEffect(alphaSlow: 0.5, alphaFast: 0.5)
+        let effectsB = input.asymmetricMomentumEffect(alphaSlow: 0.5, alphaFast: 0.5)
+        XCTAssertEqual(effectsA.count, effectsB.count)
+        for (a, b) in zip(effectsA, effectsB) {
+            XCTAssertEqual(
+                a.quantity.doubleValue(for: unit),
+                b.quantity.doubleValue(for: unit),
+                accuracy: 1e-9)
+        }
+        // And the result should still be finite & non-empty for valid input.
+        XCTAssertFalse(effectsA.isEmpty)
+        XCTAssertTrue(effectsA.allSatisfy { $0.quantity.doubleValue(for: unit).isFinite })
+    }
+
+    // MARK: - Hybrid asymmetric momentum
+
+    func testHybridReturnsEmptyOnTooFewSamples() {
+        let input = samples([100, 105])
+        let effects = input.hybridAsymmetricMomentumEffect()
+        XCTAssertTrue(effects.isEmpty)
+    }
+
+    func testHybridMatchesLinearOnSteadyRise() {
+        // Steady rise: latest instantV is consistent with regression slope, so
+        // hybrid should NOT switch to fast-EMA mode and the output should
+        // match linearMomentumEffect.
+        let input = samples([100, 105, 110, 115, 120])
+        let linear = input.linearMomentumEffect(duration: .minutes(30))
+        let hybrid = input.hybridAsymmetricMomentumEffect(duration: .minutes(30))
+        XCTAssertEqual(linear.count, hybrid.count)
+        XCTAssertFalse(linear.isEmpty)
+        for (l, h) in zip(linear, hybrid) {
+            XCTAssertEqual(l.startDate, h.startDate)
+            // Equal within tight numerical tolerance — same algorithm path
+            XCTAssertEqual(
+                l.quantity.doubleValue(for: unit),
+                h.quantity.doubleValue(for: unit),
+                accuracy: 1e-9,
+                "Hybrid should match linear on steady rise")
+        }
+    }
+
+    func testHybridDropsToFastEMAOnFall() {
+        // Build a sequence that rises then drops sharply at the end. The
+        // linear regression sees a net positive slope, but the LATEST
+        // instantaneous velocity is strongly negative — hybrid should switch
+        // to fast-EMA and produce a smaller (or negative) projected slope
+        // than linearMomentumEffect.
+        let input = samples([100, 105, 110, 115, 105])  // rises then drops
+        let linear = input.linearMomentumEffect(duration: .minutes(30))
+        let hybrid = input.hybridAsymmetricMomentumEffect(duration: .minutes(30))
+        XCTAssertEqual(linear.count, hybrid.count)
+        XCTAssertFalse(linear.isEmpty)
+        // Compare the last projected value: hybrid should be ≤ linear (less
+        // momentum projected forward when the trend has just reversed).
+        let lastLinear = linear.last!.quantity.doubleValue(for: unit)
+        let lastHybrid = hybrid.last!.quantity.doubleValue(for: unit)
+        XCTAssertLessThan(lastHybrid, lastLinear,
+            "Hybrid should temper the projected momentum on a drop. linear=\(lastLinear) hybrid=\(lastHybrid)")
+    }
+
+    func testHybridRespectsVelocityCap() {
+        // Strongly rising → cap should bound projected effect.
+        let input = samples([100, 120, 140, 160, 180])
+        let cap = LoopQuantity(unit: .milligramsPerDeciliterPerMinute, doubleValue: 1.0)
+        let effects = input.hybridAsymmetricMomentumEffect(velocityMaximum: cap, alphaFast: 0.85)
+        XCTAssertFalse(effects.isEmpty)
+        // Last projected value should not exceed cap × 30 min projection
+        let lastValue = effects.last!.quantity.doubleValue(for: unit)
+        XCTAssertLessThanOrEqual(lastValue, 30.0 + 1e-6)
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new momentum-effect computation modes to `GlucoseMath`:

1. **`asymmetricMomentumEffect`** — replaces standard linear regression with an asymmetric EMA over instantaneous velocities. Slow to build positive momentum (alphaSlow=0.15), fast to shed it (alphaFast=0.85). Designed to keep the algorithm conservative about assuming BG will keep rising, while responding immediately when it levels off or falls.

2. **`hybridAsymmetricMomentumEffect`** — uses standard linear regression for rises (matching today's `linearMomentumEffect` exactly), then switches to fast EMA when the latest instantaneous velocity falls below the regression slope. Designed to preserve normal Loop behavior on rises while damping projected momentum on drops.

Wired into `generatePrediction` via new optional parameters with backward-compatible defaults:
- `useAsymmetricMomentum: Bool = false` — opt in
- `momentumVelocityMaximum: LoopQuantity? = nil` — optional cap
- `momentumAlphaSlow: Double = 0.15`, `momentumAlphaFast: Double = 0.85` — tunables

When `useAsymmetricMomentum` is false (default), behavior is unchanged.

## Why

In LoopEval closed-loop sims, the standard linear regression projects momentum forward symmetrically — overshooting BG predictions in volatile situations. Asymmetric momentum produced measurable improvements: TIR cost is small (−1.26 pp) and hypos go down (−0.14 pp t<70), borderline-accept per the project's lows-first priority.

## Test plan

- [x] All existing tests pass
- [x] Added `AsymmetricMomentumTests.swift` with 9 tests:
  - `testAsymmetricReturnsEmptyOnTooFewSamples` — guards against insufficient data
  - `testAsymmetricVelocityCapClamps` — velocity cap bounds projected effect
  - `testAsymmetricBuildsSlowlyOnRise` — alphaSlow produces lagged response to acceleration
  - `testAsymmetricRespondsQuicklyOnDrop` — alphaFast produces fast response to drop (negative projected effect)
  - `testAsymmetricAlphaEqualBehavesLikeSimpleEMA` — symmetric case sanity check
  - `testHybridReturnsEmptyOnTooFewSamples`
  - `testHybridMatchesLinearOnSteadyRise` — equivalence: when there's no drop, hybrid output matches `linearMomentumEffect`
  - `testHybridDropsToFastEMAOnFall` — projected effect is tempered when latest instantV < regression slope
  - `testHybridRespectsVelocityCap`