### PR TITLE
Decompose glucose-effect into active-insulin + EGP-credit components (Phase 1)

### DIFF
--- a/Sources/LoopAlgorithm/Insulin/InsulinMath.swift
+++ b/Sources/LoopAlgorithm/Insulin/InsulinMath.swift
@@ -74,21 +74,63 @@ extension BasalRelativeDose {
     }
 
     func glucoseEffect(at date: Date, insulinSensitivity: Double, delta: TimeInterval) -> Double {
+        return glucoseEffect(at: date,
+                             activeSensitivity: insulinSensitivity,
+                             egpSensitivity: insulinSensitivity,
+                             delta: delta)
+    }
+
+    /// Decomposed glucose-effect: splits this dose's contribution into the
+    /// **active-insulin** piece (positive `netBasalUnits` — delivered insulin
+    /// lowering BG, scaled by `activeSensitivity`) and the **EGP-credit**
+    /// piece (negative `netBasalUnits` — shortfall vs scheduled basal, treated
+    /// as positive BG-effect, scaled by `egpSensitivity`).
+    ///
+    /// At `activeSensitivity == egpSensitivity` (the default in the single-
+    /// argument overload), output is bit-identical to the original
+    /// `netBasalUnits × -ISF × pd` formula.
+    ///
+    /// Passing different values lets sensitivity overrides (exercise, sick-
+    /// day) scale only the term they physically affect. An exercise preset
+    /// that means "insulin works 2× harder right now" should boost
+    /// `activeSensitivity` but leave `egpSensitivity` at scheduled — otherwise
+    /// the EGP-credit assumption-from-suspending also gets 2×, which is the
+    /// opposite of what the model physically represents.
+    func glucoseEffect(at date: Date,
+                       activeSensitivity: Double,
+                       egpSensitivity: Double,
+                       delta: TimeInterval) -> Double {
         let time = date.timeIntervalSince(startDate)
 
         guard time >= 0 else {
             return 0
         }
 
-        // Consider doses within the delta time window as momentary
+        let pd: Double
         if endDate.timeIntervalSince(startDate) <= 1.05 * delta {
-            return netBasalUnits * -insulinSensitivity * (1.0 - insulinModel.percentEffectRemaining(at: time))
+            pd = 1.0 - insulinModel.percentEffectRemaining(at: time)
         } else {
-            return netBasalUnits * -insulinSensitivity * continuousDeliveryPercentEffect(at: date, delta: delta)
+            pd = continuousDeliveryPercentEffect(at: date, delta: delta)
         }
+        let nbu = netBasalUnits
+        let active = Swift.max(0, nbu)       // delivered-above-schedule (lowers BG)
+        let egpCredit = Swift.min(0, nbu)    // shortfall-vs-schedule (raises BG; EGP credit)
+        return active * -activeSensitivity * pd + egpCredit * -egpSensitivity * pd
     }
 
     func glucoseEffect(during interval: DateInterval, insulinSensitivity: Double, delta: TimeInterval) -> Double {
+        return glucoseEffect(during: interval,
+                             activeSensitivity: insulinSensitivity,
+                             egpSensitivity: insulinSensitivity,
+                             delta: delta)
+    }
+
+    /// Interval-form decomposed glucose-effect. Same split convention as the
+    /// point-form `glucoseEffect(at:activeSensitivity:egpSensitivity:delta:)`.
+    func glucoseEffect(during interval: DateInterval,
+                       activeSensitivity: Double,
+                       egpSensitivity: Double,
+                       delta: TimeInterval) -> Double {
         let start = interval.start.timeIntervalSince(startDate)
         let end = interval.end.timeIntervalSince(startDate)
 
@@ -96,7 +138,6 @@ extension BasalRelativeDose {
             return 0
         }
 
-        // Consider doses within the delta time window as momentary
         let effect: Double
         if endDate.timeIntervalSince(startDate) <= 1.05 * delta {
             effect = insulinModel.percentEffectRemaining(at: start) - insulinModel.percentEffectRemaining(at: end)
@@ -105,7 +146,10 @@ extension BasalRelativeDose {
             let endPercentRemaining = 1 - continuousDeliveryPercentEffect(at: interval.end, delta: delta)
             effect = startPercentRemaining - endPercentRemaining
         }
-        return netBasalUnits * -insulinSensitivity * effect
+        let nbu = netBasalUnits
+        let active = Swift.max(0, nbu)
+        let egpCredit = Swift.min(0, nbu)
+        return active * -activeSensitivity * effect + egpCredit * -egpSensitivity * effect
     }
 }
 
@@ -342,6 +386,29 @@ extension Collection where Element == BasalRelativeDose {
         to end: Date? = nil,
         delta: TimeInterval = TimeInterval(/* minutes: */60 * 5)
     ) -> [GlucoseEffect] {
+        return glucoseEffects(insulinSensitivityHistory: insulinSensitivityHistory,
+                              egpSensitivityHistory: nil,
+                              from: start, to: end, delta: delta)
+    }
+
+    /// Decomposed glucose-effects: applies `insulinSensitivityHistory` to the
+    /// active-insulin (positive `netBasalUnits`) component of each dose, and
+    /// `egpSensitivityHistory` (when non-nil) to the EGP-credit (negative
+    /// `netBasalUnits`) component. When `egpSensitivityHistory` is nil,
+    /// behavior is identical to the single-ISF overload.
+    ///
+    /// Sensitivity overrides (exercise / sick-day) should pass an
+    /// `insulinSensitivityHistory` that reflects the override AND an
+    /// `egpSensitivityHistory` that reflects only the EGP-rate change
+    /// (typically none, so pass the scheduled ISF). This decouples the two
+    /// physical quantities the prior single-schedule API conflated.
+    public func glucoseEffects(
+        insulinSensitivityHistory: [AbsoluteScheduleValue<LoopQuantity>],
+        egpSensitivityHistory: [AbsoluteScheduleValue<LoopQuantity>]?,
+        from start: Date? = nil,
+        to end: Date? = nil,
+        delta: TimeInterval = TimeInterval(/* minutes: */60 * 5)
+    ) -> [GlucoseEffect] {
 
         let activeEntries = self.filter({ entry in
             entry.netBasalUnits != 0
@@ -357,13 +424,22 @@ extension Collection where Element == BasalRelativeDose {
 
         repeat {
             let value = reduce(0) { (value, dose) -> Double in
-
-                guard let isfScheduleValue = insulinSensitivityHistory.closestPrior(to: dose.startDate), isfScheduleValue.endDate >= dose.startDate else {
-                    preconditionFailure("ISF History must cover dose startDates")
+                guard let activeEntry = insulinSensitivityHistory.closestPrior(to: dose.startDate), activeEntry.endDate >= dose.startDate else {
+                    preconditionFailure("ISF history must cover dose startDates")
                 }
-                let isf = isfScheduleValue.value.doubleValue(for: unit)
-                let doseEffect = dose.glucoseEffect(at: date, insulinSensitivity: isf, delta: delta)
-                return value + doseEffect
+                let activeISF = activeEntry.value.doubleValue(for: unit)
+                let egpISF: Double
+                if let egp = egpSensitivityHistory,
+                   let egpEntry = egp.closestPrior(to: dose.startDate),
+                   egpEntry.endDate >= dose.startDate {
+                    egpISF = egpEntry.value.doubleValue(for: unit)
+                } else {
+                    egpISF = activeISF
+                }
+                return value + dose.glucoseEffect(at: date,
+                                                  activeSensitivity: activeISF,
+                                                  egpSensitivity: egpISF,
+                                                  delta: delta)
             }
 
             values.append(GlucoseEffect(startDate: date, quantity: LoopQuantity(unit: unit, doubleValue: value)))
@@ -391,6 +467,32 @@ extension Collection where Element == BasalRelativeDose {
         to end: Date? = nil,
         delta: TimeInterval = TimeInterval(/* minutes: */60 * 5)
     ) -> [GlucoseEffect] {
+        return glucoseEffectsMidAbsorptionISF(
+            longestEffectDuration: longestEffectDuration,
+            insulinSensitivityHistory: insulinSensitivityHistory,
+            egpSensitivityHistory: nil,
+            from: start, to: end, delta: delta
+        )
+    }
+
+    /// Decomposed mid-absorption-ISF glucose effects. Same role as the single-
+    /// ISF overload but separately accepts `egpSensitivityHistory` for the
+    /// EGP-credit (negative `netBasalUnits`) component. When
+    /// `egpSensitivityHistory` is nil, behavior is identical to the single-
+    /// ISF overload.
+    ///
+    /// Assumes `egpSensitivityHistory` (when non-nil) has the same time
+    /// boundaries as `insulinSensitivityHistory` — typical when both come
+    /// from the same scheduled-ISF source with an override multiplier applied
+    /// to only one of them.
+    public func glucoseEffectsMidAbsorptionISF(
+        longestEffectDuration: TimeInterval = InsulinMath.defaultInsulinActivityDuration,
+        insulinSensitivityHistory: [AbsoluteScheduleValue<LoopQuantity>],
+        egpSensitivityHistory: [AbsoluteScheduleValue<LoopQuantity>]?,
+        from start: Date? = nil,
+        to end: Date? = nil,
+        delta: TimeInterval = TimeInterval(/* minutes: */60 * 5)
+    ) -> [GlucoseEffect] {
         guard let (start, end) = LoopMath.simulationDateRangeForSamples(self.filter({ entry in
             entry.netBasalUnits != 0
         }), from: start, to: end, duration: longestEffectDuration, delta: delta) else {
@@ -404,13 +506,11 @@ extension Collection where Element == BasalRelativeDose {
 
         var value: Double = 0
         repeat {
-            // Sum effects over doses
             value = reduce(value) { (value, dose) -> Double in
                 guard date != lastDate else {
                     return 0
                 }
 
-                // Sum effects over pertinent ISF timeline segments
                 let isfSegments = insulinSensitivityHistory.filterDateRange(lastDate, date)
                 if isfSegments.count == 0 {
                     preconditionFailure("ISF Timeline must cover dose absorption duration")
@@ -419,7 +519,18 @@ extension Collection where Element == BasalRelativeDose {
                     let start = Swift.max(lastDate, segment.startDate)
                     let end = Swift.min(date, segment.endDate)
                     if start != end {
-                        let effect = dose.glucoseEffect(during: DateInterval(start: start, end: end), insulinSensitivity: segment.value.doubleValue(for: unit), delta: delta)
+                        let activeISF = segment.value.doubleValue(for: unit)
+                        let egpISF: Double
+                        if let egp = egpSensitivityHistory,
+                           let e = egp.closestPrior(to: start), e.endDate >= start {
+                            egpISF = e.value.doubleValue(for: unit)
+                        } else {
+                            egpISF = activeISF
+                        }
+                        let effect = dose.glucoseEffect(during: DateInterval(start: start, end: end),
+                                                        activeSensitivity: activeISF,
+                                                        egpSensitivity: egpISF,
+                                                        delta: delta)
                         return partialResult + effect
                     } else {
                         return partialResult

--- a/Sources/LoopAlgorithm/LoopAlgorithm.swift
+++ b/Sources/LoopAlgorithm/LoopAlgorithm.swift
@@ -179,7 +179,16 @@ public struct LoopAlgorithm {
         includingPositiveVelocityAndRC: Bool = true,
         useMidAbsorptionISF: Bool = false,
         carbAbsorptionModel: CarbAbsorptionComputable = PiecewiseLinearAbsorption(),
-        gradualTransitionsThreshold: Double? = 40.0
+        gradualTransitionsThreshold: Double? = 40.0,
+        // Phase 1: optional separate sensitivity schedule for the EGP-credit
+        // component of insulin effects (the contribution from negative
+        // `netBasalUnits`). When nil (default), `sensitivity` is used for
+        // both the active-insulin and EGP-credit components — bit-identical
+        // to the prior single-schedule behavior. Pass a separate schedule
+        // when an override (e.g. exercise) should scale active-insulin
+        // sensitivity without amplifying the model's implicit EGP-credit
+        // assumption. See [[project_loopalgo_active_insulin_egp_decomposition]].
+        egpSensitivity: [AbsoluteScheduleValue<LoopQuantity>]? = nil
     ) -> LoopPrediction<CarbType> where CarbType: CarbEntry, GlucoseType: GlucoseSampleValue, InsulinDoseType: InsulinDose {
 
         var prediction: [PredictedGlucoseValue] = []
@@ -217,11 +226,13 @@ public struct LoopAlgorithm {
             if useMidAbsorptionISF {
                 insulinEffects = dosesRelativeToBasal.glucoseEffectsMidAbsorptionISF(
                     insulinSensitivityHistory: sensitivity,
+                    egpSensitivityHistory: egpSensitivity,
                     from: insulinEffectsInterval.start,
                     to: insulinEffectsInterval.end)
             } else {
                 insulinEffects = dosesRelativeToBasal.glucoseEffects(
                     insulinSensitivityHistory: sensitivity,
+                    egpSensitivityHistory: egpSensitivity,
                     from: insulinEffectsInterval.start,
                     to: insulinEffectsInterval.end)
             }

--- a/Tests/LoopAlgorithmTests/ActiveInsulinEgpDecompositionTests.swift
+++ b/Tests/LoopAlgorithmTests/ActiveInsulinEgpDecompositionTests.swift
@@ -1,0 +1,310 @@
+//
+//  ActiveInsulinEgpDecompositionTests.swift
+//  LoopAlgorithm
+//
+//  Tests for Phase 1 of the active-insulin vs EGP decomposition: the
+//  glucose-effect computation now accepts SEPARATE sensitivity schedules
+//  for the active-insulin (positive `netBasalUnits`) component and the
+//  EGP-credit (negative `netBasalUnits`) component. At a single ISF (the
+//  default — no `egpSensitivityHistory` argument) the output is bit-
+//  identical to the prior behavior.
+//
+
+import XCTest
+@testable import LoopAlgorithm
+
+final class ActiveInsulinEgpDecompositionTests: XCTestCase {
+
+    private let unit = LoopUnit.milligramsPerDeciliter
+    private let dia = InsulinMath.defaultInsulinActivityDuration
+
+    private let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
+
+    private func date(_ s: String) -> Date { dateFormatter.date(from: s)! }
+
+    private func constantISF(_ mgdlPerU: Double, around t: Date,
+                              span: TimeInterval = .hours(24)) -> [AbsoluteScheduleValue<LoopQuantity>] {
+        return [AbsoluteScheduleValue(
+            startDate: t.addingTimeInterval(-span),
+            endDate:   t.addingTimeInterval(span),
+            value: LoopQuantity(unit: .milligramsPerDeciliter, doubleValue: mgdlPerU)
+        )]
+    }
+
+    // MARK: - Per-dose API
+
+    /// When the same value is passed for both active and egp sensitivities,
+    /// the decomposed call must match the single-ISF call exactly.
+    func testDecomposedMatchesSingleISFWhenSchedulesEqual() {
+        let start = date("2025-01-01T12:00:00")
+        let doses: [BasalRelativeDose] = [
+            BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 1.5),
+            BasalRelativeDose(
+                type: .basal(scheduledRate: 1.0),
+                startDate: start.addingTimeInterval(.hours(1)),
+                endDate:   start.addingTimeInterval(.hours(2)),
+                volume: 0.0
+            ),
+        ]
+        for dose in doses {
+            for tau in [TimeInterval(.minutes(15)), .minutes(60), .minutes(180), dia, dia + .hours(2)] {
+                let t = start.addingTimeInterval(tau)
+                let single = dose.glucoseEffect(at: t, insulinSensitivity: 50.0, delta: .minutes(5))
+                let decomp = dose.glucoseEffect(at: t,
+                                                activeSensitivity: 50.0,
+                                                egpSensitivity: 50.0,
+                                                delta: .minutes(5))
+                XCTAssertEqual(single, decomp, accuracy: 1e-12,
+                    "Single-ISF and decomposed-with-equal-ISFs must produce identical results")
+            }
+        }
+    }
+
+    /// Boosting active-sensitivity scales the BOLUS effect but NOT the
+    /// EGP-credit effect (which comes from negative-net doses).
+    func testActiveSensitivityBoostScalesOnlyBolusEffect() {
+        let start = date("2025-01-01T12:00:00")
+        let bolus = BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 1.0)
+        let evalT = start.addingTimeInterval(dia)
+        let baseline = bolus.glucoseEffect(at: evalT, activeSensitivity: 50, egpSensitivity: 50, delta: .minutes(5))
+        let activeDoubled = bolus.glucoseEffect(at: evalT, activeSensitivity: 100, egpSensitivity: 50, delta: .minutes(5))
+        XCTAssertEqual(activeDoubled, 2.0 * baseline, accuracy: 1e-9,
+            "Doubling active sensitivity must double a bolus's effect")
+    }
+
+    func testEgpSensitivityDoesNotAffectBolus() {
+        let start = date("2025-01-01T12:00:00")
+        let bolus = BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 1.0)
+        let evalT = start.addingTimeInterval(dia)
+        let base = bolus.glucoseEffect(at: evalT, activeSensitivity: 50, egpSensitivity: 50, delta: .minutes(5))
+        let egpDoubled = bolus.glucoseEffect(at: evalT, activeSensitivity: 50, egpSensitivity: 100, delta: .minutes(5))
+        XCTAssertEqual(base, egpDoubled, accuracy: 1e-12,
+            "EGP sensitivity must NOT affect a bolus (netBasalUnits > 0)")
+    }
+
+    func testEgpSensitivityScalesOnlySuspendEffect() {
+        let start = date("2025-01-01T12:00:00")
+        let suspend = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start, endDate: start.addingTimeInterval(.hours(1)),
+            volume: 0.0
+        )
+        let evalT = start.addingTimeInterval(dia + .hours(1))
+        let base = suspend.glucoseEffect(at: evalT, activeSensitivity: 50, egpSensitivity: 50, delta: .minutes(5))
+        let activeDoubled = suspend.glucoseEffect(at: evalT, activeSensitivity: 100, egpSensitivity: 50, delta: .minutes(5))
+        XCTAssertEqual(base, activeDoubled, accuracy: 1e-12,
+            "Active sensitivity must NOT affect a suspended-temp (netBasalUnits < 0)")
+
+        let egpDoubled = suspend.glucoseEffect(at: evalT, activeSensitivity: 50, egpSensitivity: 100, delta: .minutes(5))
+        XCTAssertEqual(egpDoubled, 2.0 * base, accuracy: 1e-9,
+            "Doubling EGP sensitivity must double a suspended-temp's effect")
+    }
+
+    func testNetZeroDoseUnaffectedByEitherSensitivity() {
+        let start = date("2025-01-01T12:00:00")
+        let neutral = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start, endDate: start.addingTimeInterval(.hours(1)),
+            volume: 1.0  // matches scheduled → net = 0
+        )
+        let evalT = start.addingTimeInterval(dia)
+        for active in [10.0, 50.0, 100.0] {
+            for egp in [10.0, 50.0, 100.0] {
+                let v = neutral.glucoseEffect(at: evalT,
+                                              activeSensitivity: active,
+                                              egpSensitivity: egp,
+                                              delta: .minutes(5))
+                XCTAssertEqual(v, 0.0, accuracy: 1e-12,
+                    "Net-zero dose must produce zero effect for any sensitivity pair (active=\(active), egp=\(egp))")
+            }
+        }
+    }
+
+    // MARK: - Collection-level glucoseEffects
+
+    func testCollectionLevelDecomposedMatchesSingleWhenSchedulesEqual() {
+        let start = date("2025-01-01T12:00:00")
+        let doses: [BasalRelativeDose] = [
+            BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 2.0),
+            BasalRelativeDose(
+                type: .basal(scheduledRate: 1.0),
+                startDate: start.addingTimeInterval(.hours(2)),
+                endDate:   start.addingTimeInterval(.hours(3)),
+                volume: 0.0
+            ),
+        ]
+        let isf = constantISF(50.0, around: start)
+        let single = doses.glucoseEffects(insulinSensitivityHistory: isf)
+        let decompNilEgp = doses.glucoseEffects(insulinSensitivityHistory: isf, egpSensitivityHistory: nil)
+        let decompMatching = doses.glucoseEffects(insulinSensitivityHistory: isf, egpSensitivityHistory: isf)
+        XCTAssertEqual(single.count, decompNilEgp.count)
+        XCTAssertEqual(single.count, decompMatching.count)
+        for i in 0..<single.count {
+            let s = single[i].quantity.doubleValue(for: unit)
+            let d1 = decompNilEgp[i].quantity.doubleValue(for: unit)
+            let d2 = decompMatching[i].quantity.doubleValue(for: unit)
+            XCTAssertEqual(s, d1, accuracy: 1e-9)
+            XCTAssertEqual(s, d2, accuracy: 1e-9)
+        }
+    }
+
+    func testCollectionLevelOverrideBoostsOnlyActiveComponent() {
+        // Set up a dose history with both a bolus AND a suspended temp.
+        // Apply an active-side boost (insulinSensitivity × 2) but leave EGP
+        // schedule at scheduled (× 1). The combined effect should equal:
+        //   2 × bolus_effect + 1 × suspend_effect (= -200 + 50 at asymptote for these values)
+        // vs the SINGLE-schedule × 2 result which would over-amplify both:
+        //   2 × bolus_effect + 2 × suspend_effect (= -200 + 100)
+        let start = date("2025-01-01T12:00:00")
+        let bolus = BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 2.0)
+        let suspend = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start.addingTimeInterval(.hours(2)),
+            endDate:   start.addingTimeInterval(.hours(3)),
+            volume: 0.0  // net = -1
+        )
+
+        let baseISF = constantISF(50.0, around: start)
+        let boostedISF = constantISF(100.0, around: start)
+        let endTime = start.addingTimeInterval(dia + .hours(4))
+
+        // Asymptotic single-schedule × 1 = -2 × 50 + (-1) × -50 = -100 + 50 = -50
+        let single = [bolus, suspend].glucoseEffects(
+            insulinSensitivityHistory: baseISF,
+            from: start, to: endTime
+        )
+        XCTAssertEqual(single.last!.quantity.doubleValue(for: unit), -50.0, accuracy: 0.5,
+            "Asymptote single-schedule = -100 + 50 = -50")
+
+        // Asymptotic single-schedule × 2 (WRONG WAY — over-amplifies EGP) = -200 + 100 = -100
+        let singleBoosted = [bolus, suspend].glucoseEffects(
+            insulinSensitivityHistory: boostedISF,
+            from: start, to: endTime
+        )
+        XCTAssertEqual(singleBoosted.last!.quantity.doubleValue(for: unit), -100.0, accuracy: 0.5,
+            "Asymptote single-schedule-doubled = -200 + 100 = -100 (the OLD over-amplifying behavior)")
+
+        // Asymptotic active-doubled, egp-unchanged (the FIX) = -200 + 50 = -150
+        let decomposed = [bolus, suspend].glucoseEffects(
+            insulinSensitivityHistory: boostedISF,
+            egpSensitivityHistory: baseISF,
+            from: start, to: endTime
+        )
+        XCTAssertEqual(decomposed.last!.quantity.doubleValue(for: unit), -150.0, accuracy: 0.5,
+            "Asymptote with active×2, egp×1: -2 × 100 + (-1) × -50 = -150")
+
+        // The decomposed result must differ from BOTH single-schedule cases.
+        XCTAssertNotEqual(decomposed.last!.quantity.doubleValue(for: unit),
+                          single.last!.quantity.doubleValue(for: unit))
+        XCTAssertNotEqual(decomposed.last!.quantity.doubleValue(for: unit),
+                          singleBoosted.last!.quantity.doubleValue(for: unit))
+    }
+
+    // MARK: - Mid-absorption variant
+
+    func testMidAbsorptionDecomposedMatchesSingleWhenSchedulesEqual() {
+        let start = date("2025-01-01T12:00:00")
+        let doses: [BasalRelativeDose] = [
+            BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 1.0),
+            BasalRelativeDose(
+                type: .basal(scheduledRate: 0.8),
+                startDate: start.addingTimeInterval(.hours(1)),
+                endDate:   start.addingTimeInterval(.hours(2)),
+                volume: 0.0
+            ),
+        ]
+        let isf = constantISF(45.0, around: start)
+        let single = doses.glucoseEffectsMidAbsorptionISF(insulinSensitivityHistory: isf)
+        let decomp = doses.glucoseEffectsMidAbsorptionISF(insulinSensitivityHistory: isf, egpSensitivityHistory: isf)
+        let decompNil = doses.glucoseEffectsMidAbsorptionISF(insulinSensitivityHistory: isf, egpSensitivityHistory: nil)
+        XCTAssertEqual(single.count, decomp.count)
+        for i in 0..<single.count {
+            XCTAssertEqual(
+                single[i].quantity.doubleValue(for: unit),
+                decomp[i].quantity.doubleValue(for: unit),
+                accuracy: 1e-9)
+            XCTAssertEqual(
+                single[i].quantity.doubleValue(for: unit),
+                decompNil[i].quantity.doubleValue(for: unit),
+                accuracy: 1e-9)
+        }
+    }
+
+    // MARK: - End-to-end through LoopAlgorithm.generatePrediction
+
+    /// `generatePrediction(..., egpSensitivity: nil)` must produce a
+    /// prediction bit-identical to the prior single-schedule API.
+    func testGeneratePredictionNilEgpMatchesSingleSchedule() {
+        let start = date("2025-01-01T12:00:00")
+        let dose = BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 1.0)
+        let glucose: [GlucoseFixtureValue] = (0..<7).map { i in
+            GlucoseFixtureValue(
+                startDate: start.addingTimeInterval(TimeInterval(-30 + 5 * i) * 60),
+                quantity: LoopQuantity(unit: unit, doubleValue: 150),
+                isDisplayOnly: false, wasUserEntered: false,
+                provenanceIdentifier: "test", condition: nil, trendRate: nil
+            )
+        }
+        let basal: [AbsoluteScheduleValue<Double>] = [AbsoluteScheduleValue(
+            startDate: start.addingTimeInterval(-.hours(6)),
+            endDate: start.addingTimeInterval(.hours(12)),
+            value: 1.0
+        )]
+        let sensitivity = constantISF(50.0, around: start)
+        let carbRatio: [AbsoluteScheduleValue<Double>] = [AbsoluteScheduleValue(
+            startDate: start.addingTimeInterval(-.hours(6)),
+            endDate: start.addingTimeInterval(.hours(12)),
+            value: 10.0
+        )]
+
+        let predA = LoopAlgorithm.generatePrediction(
+            start: start, glucoseHistory: glucose, doses: [dose],
+            carbEntries: [FixtureCarbEntry](),  // dummy stand-in for CarbEntry collection? Better: empty CarbEntry array
+            basal: basal, sensitivity: sensitivity, carbRatio: carbRatio,
+            useMidAbsorptionISF: true,
+            egpSensitivity: nil
+        )
+        let predB = LoopAlgorithm.generatePrediction(
+            start: start, glucoseHistory: glucose, doses: [dose],
+            carbEntries: [FixtureCarbEntry](),
+            basal: basal, sensitivity: sensitivity, carbRatio: carbRatio,
+            useMidAbsorptionISF: true,
+            egpSensitivity: sensitivity  // same as insulin → must match nil-case
+        )
+        XCTAssertEqual(predA.glucose.count, predB.glucose.count)
+        for i in 0..<predA.glucose.count {
+            XCTAssertEqual(
+                predA.glucose[i].quantity.doubleValue(for: unit),
+                predB.glucose[i].quantity.doubleValue(for: unit),
+                accuracy: 1e-9)
+        }
+    }
+
+    func testMidAbsorptionOverrideBoostsOnlyActiveComponent() {
+        // Mirror of testCollectionLevelOverrideBoostsOnlyActiveComponent but
+        // using mid-absorption ISF (which integrates ISF per absorption sub-interval).
+        let start = date("2025-01-01T12:00:00")
+        let bolus = BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 2.0)
+        let suspend = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start.addingTimeInterval(.hours(2)),
+            endDate:   start.addingTimeInterval(.hours(3)),
+            volume: 0.0
+        )
+        let baseISF = constantISF(50.0, around: start)
+        let boostedISF = constantISF(100.0, around: start)
+
+        let decomp = [bolus, suspend].glucoseEffectsMidAbsorptionISF(
+            insulinSensitivityHistory: boostedISF,
+            egpSensitivityHistory: baseISF
+        )
+        XCTAssertEqual(decomp.last!.quantity.doubleValue(for: unit), -150.0, accuracy: 0.5,
+            "Mid-abs decomposed asymptote with active×2, egp×1: -150")
+    }
+}

--- a/Tests/LoopAlgorithmTests/Phase1BackstopTests.swift
+++ b/Tests/LoopAlgorithmTests/Phase1BackstopTests.swift
@@ -1,0 +1,364 @@
+//
+//  Phase1BackstopTests.swift
+//  LoopAlgorithm
+//
+//  Backstop tests for the upcoming "active-insulin vs EGP decomposition"
+//  refactor. The refactor will split `BasalRelativeDose.glucoseEffect` so
+//  that the active-insulin component (positive `netBasalUnits`) and the
+//  EGP-credit component (negative `netBasalUnits`) can be scaled
+//  independently by insulin-sensitivity multipliers / overrides.
+//
+//  These tests pin down today's BEHAVIOR — at the default schedule (no
+//  override / mult = 1.0) the decomposed version must continue to produce
+//  identical output. The asserts cover:
+//
+//   - Sign convention of `glucoseEffect`: positive netBasalUnits → negative
+//     BG-effect rate (insulin lowers BG); negative netBasalUnits → positive
+//     BG-effect rate (EGP credit from suspending).
+//   - Magnitude: `effect_at_asymptote ≈ netBasalUnits × -ISF` once the dose
+//     has fully decayed.
+//   - Net-zero dose: a temp basal that exactly matches scheduled basal
+//     produces zero glucose effect (no spurious EGP credit or active-
+//     insulin effect).
+//   - Sign symmetry: a +U bolus and a -U bolus (same magnitude) produce
+//     mirror-image effects.
+//   - Linearity: the effect of a mixed-sign dose history equals the sum of
+//     the per-dose effects (no cross-talk).
+//   - `glucoseEffects` and `glucoseEffectsMidAbsorptionISF` agree when the
+//     sensitivity schedule is constant across the absorption window.
+//   - `insulinCorrection` reads the FULL sensitivity schedule across its
+//     forecast horizon (so the post-refactor decomposed call doesn't
+//     accidentally collapse to the at-t value).
+//
+
+import XCTest
+@testable import LoopAlgorithm
+
+final class Phase1BackstopTests: XCTestCase {
+
+    private let unit = LoopUnit.milligramsPerDeciliter
+    private let dia = InsulinMath.defaultInsulinActivityDuration  // 6h
+
+    private let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
+
+    private func date(_ s: String) -> Date { dateFormatter.date(from: s)! }
+
+    /// Build a constant ISF schedule that covers the dose effect window.
+    private func constantISF(_ mgdlPerU: Double, around t: Date,
+                              span: TimeInterval = .hours(24)) -> [AbsoluteScheduleValue<LoopQuantity>] {
+        return [AbsoluteScheduleValue(
+            startDate: t.addingTimeInterval(-span),
+            endDate:   t.addingTimeInterval(span),
+            value: LoopQuantity(unit: .milligramsPerDeciliter, doubleValue: mgdlPerU)
+        )]
+    }
+
+    // MARK: - Per-dose glucoseEffect: sign convention
+
+    func testBolusProducesNegativeBgEffect() {
+        // Positive netBasalUnits → BG-effect should be NEGATIVE (BG lowering).
+        let start = date("2025-01-01T12:00:00")
+        let dose = BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 1.0)
+        XCTAssertEqual(dose.netBasalUnits, 1.0, accuracy: 1e-9)
+        // Evaluate well past peak (at DIA, effect is fully delivered).
+        let v = dose.glucoseEffect(
+            at: start.addingTimeInterval(dia),
+            insulinSensitivity: 50.0,
+            delta: .minutes(5)
+        )
+        XCTAssertLessThan(v, 0, "+1 U bolus must produce negative BG effect")
+        XCTAssertEqual(v, 1.0 * -50.0, accuracy: 0.001,
+            "At asymptote (>= DIA), effect = netUnits × -ISF: \(v) vs \(1.0 * -50.0)")
+    }
+
+    func testNegativeNetUnitsProducesPositiveBgEffect() {
+        // Suspended temp basal: deliver 0 U/hr for 1 hour while scheduled is
+        // 1.0 U/hr → netBasalUnits = 0 - 1.0×1.0 = -1.0.
+        // → BG-effect should be POSITIVE (EGP credit).
+        let start = date("2025-01-01T12:00:00")
+        let dose = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start,
+            endDate: start.addingTimeInterval(.hours(1)),
+            volume: 0.0  // suspended
+        )
+        XCTAssertEqual(dose.netBasalUnits, -1.0, accuracy: 1e-9)
+        // For temp basal segments, evaluate after the segment+activity window
+        // so the effect is fully integrated.
+        let v = dose.glucoseEffect(
+            at: start.addingTimeInterval(dia + .hours(1)),
+            insulinSensitivity: 50.0,
+            delta: .minutes(5)
+        )
+        XCTAssertGreaterThan(v, 0, "Suspending below scheduled basal must produce positive BG effect (EGP credit)")
+        XCTAssertEqual(v, -1.0 * -50.0, accuracy: 0.001,
+            "At asymptote: effect = netUnits × -ISF = (-1.0) × (-50.0) = +50.0; got \(v)")
+    }
+
+    func testNetZeroDoseProducesZeroEffect() {
+        // Temp basal that matches scheduled basal: deliver 1.0 U/hr for 1 hr
+        // while scheduled is 1.0 U/hr → netBasalUnits = 0.
+        let start = date("2025-01-01T12:00:00")
+        let dose = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start,
+            endDate: start.addingTimeInterval(.hours(1)),
+            volume: 1.0  // matches scheduled
+        )
+        XCTAssertEqual(dose.netBasalUnits, 0.0, accuracy: 1e-9)
+        // Effect must be exactly zero — no spurious active-insulin or EGP-credit.
+        for tau in [TimeInterval(.minutes(15)), .minutes(60), .minutes(180), dia] {
+            let v = dose.glucoseEffect(
+                at: start.addingTimeInterval(tau),
+                insulinSensitivity: 50.0,
+                delta: .minutes(5)
+            )
+            XCTAssertEqual(v, 0.0, accuracy: 1e-12,
+                "Net-zero dose should produce zero effect at all times; at \(tau) got \(v)")
+        }
+    }
+
+    // MARK: - Sign symmetry and linearity
+
+    func testSignSymmetryBolus() {
+        // +1 U bolus and -1 U "anti-bolus" (constructed via suspended-vs-
+        // scheduled subtraction conceptually — but here we use direct
+        // negative-volume as a stand-in) produce mirror-image effects.
+        // BasalRelativeDose doesn't allow negative bolus volume; use a temp
+        // basal with double-rate vs scheduled to get a +1 net, and a temp
+        // basal with zero rate to get a -1 net, both over the same 1 hr.
+        let start = date("2025-01-01T12:00:00")
+        let plusOne = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start, endDate: start.addingTimeInterval(.hours(1)),
+            volume: 2.0  // double scheduled → net = +1
+        )
+        let minusOne = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start, endDate: start.addingTimeInterval(.hours(1)),
+            volume: 0.0  // suspended → net = -1
+        )
+        XCTAssertEqual(plusOne.netBasalUnits, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(minusOne.netBasalUnits, -1.0, accuracy: 1e-9)
+        let times: [TimeInterval] = [.minutes(30), .minutes(60), .minutes(180), .minutes(360), .minutes(420)]
+        for tau in times {
+            let evalT = start.addingTimeInterval(tau)
+            let p = plusOne.glucoseEffect(at: evalT, insulinSensitivity: 50.0, delta: .minutes(5))
+            let m = minusOne.glucoseEffect(at: evalT, insulinSensitivity: 50.0, delta: .minutes(5))
+            XCTAssertEqual(p, -m, accuracy: 1e-9,
+                "+1 and -1 net should be mirror images at tau=\(tau): p=\(p), m=\(m)")
+        }
+    }
+
+    func testLinearityOfMixedSignHistory() {
+        // Effect of [bolus + suspend] = effect_of(bolus) + effect_of(suspend),
+        // verified after both doses have fully decayed (asymptotic values).
+        let start = date("2025-01-01T12:00:00")
+        let bolus = BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 1.0)
+        let suspend = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start.addingTimeInterval(.hours(2)),
+            endDate: start.addingTimeInterval(.hours(3)),
+            volume: 0.0
+        )
+        let isf = constantISF(50.0, around: start)
+        // Both doses' activity ends by start + 3h + DIA = start + 9h. Check
+        // a few points after that.
+        let suspendEnd = start.addingTimeInterval(.hours(3))
+        let asymTimes = [suspendEnd.addingTimeInterval(dia + .minutes(30)),
+                         suspendEnd.addingTimeInterval(dia + .hours(1))]
+        let effectsBoth = [bolus, suspend].glucoseEffects(
+            insulinSensitivityHistory: isf,
+            from: start,
+            to: asymTimes.last!
+        )
+        let effectsBolus = [bolus].glucoseEffects(
+            insulinSensitivityHistory: isf,
+            from: start,
+            to: asymTimes.last!
+        )
+        let effectsSuspend = [suspend].glucoseEffects(
+            insulinSensitivityHistory: isf,
+            from: start,
+            to: asymTimes.last!
+        )
+        XCTAssertFalse(effectsBoth.isEmpty)
+        XCTAssertEqual(effectsBoth.count, effectsBolus.count)
+        XCTAssertEqual(effectsBoth.count, effectsSuspend.count)
+        var maxAbsErr = 0.0
+        for i in 0..<effectsBoth.count {
+            let combined = effectsBoth[i].quantity.doubleValue(for: unit)
+            let bolusVal = effectsBolus[i].quantity.doubleValue(for: unit)
+            let suspVal  = effectsSuspend[i].quantity.doubleValue(for: unit)
+            maxAbsErr = max(maxAbsErr, abs(combined - (bolusVal + suspVal)))
+        }
+        XCTAssertLessThan(maxAbsErr, 0.01,
+            "Combined effect should equal sum of components across the full timeline; max |err| = \(maxAbsErr)")
+        // And specifically at the asymptote: combined ≈ bolus_asym + suspend_asym = -50 + 50 = 0
+        let lastBoth = effectsBoth.last!.quantity.doubleValue(for: unit)
+        XCTAssertEqual(lastBoth, 0, accuracy: 0.5,
+            "Asymptotic combined effect of +1 U bolus + -1 U net suspend ≈ 0; got \(lastBoth)")
+    }
+
+    // MARK: - glucoseEffects ↔ glucoseEffectsMidAbsorptionISF agreement (constant ISF)
+
+    func testGlucoseEffectsMidAbsorptionEqualsStandardWhenISFConstant() {
+        // When sensitivity is constant across the absorption window, the
+        // mid-absorption variant must produce equal output to the standard one.
+        let start = date("2025-01-01T12:00:00")
+        let doses: [BasalRelativeDose] = [
+            BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 2.0),
+            BasalRelativeDose(
+                type: .basal(scheduledRate: 1.0),
+                startDate: start.addingTimeInterval(.hours(1)),
+                endDate:   start.addingTimeInterval(.hours(3)),
+                volume: 0.0
+            ),
+            BasalRelativeDose(type: .bolus,
+                              startDate: start.addingTimeInterval(.hours(2)),
+                              endDate:   start.addingTimeInterval(.hours(2)),
+                              volume: 0.5),
+        ]
+        let isf = constantISF(45.0, around: start)
+        let standard = doses.glucoseEffects(insulinSensitivityHistory: isf)
+        let midAbs = doses.glucoseEffectsMidAbsorptionISF(insulinSensitivityHistory: isf)
+        XCTAssertEqual(standard.count, midAbs.count)
+        for (s, m) in zip(standard, midAbs) {
+            XCTAssertEqual(s.startDate, m.startDate)
+            XCTAssertEqual(
+                s.quantity.doubleValue(for: unit),
+                m.quantity.doubleValue(for: unit),
+                accuracy: 0.01,
+                "standard and mid-abs ISF must agree when ISF is constant")
+        }
+    }
+
+    // MARK: - insulinCorrection reads the full schedule across forecast horizon
+
+    func testInsulinCorrectionUsesFullSensitivitySchedule() {
+        // Construct a prediction that drops uniformly across the forecast
+        // horizon, and a sensitivity SCHEDULE with TWO different values:
+        // 50 mg/dL/U for the first half-horizon, 100 mg/dL/U for the second.
+        // The correction units required to bring BG to target should reflect
+        // the integrated sensitivity over the prediction's absorption window,
+        // NOT just the value at delivery time.
+        let model = ExponentialInsulinModelPreset.rapidActingAdult.model
+        let deliveryDate = date("2025-01-01T12:00:00")
+        let halfHorizon: TimeInterval = model.effectDuration / 2
+
+        // Prediction: a constant BG of 200 mg/dL across the full horizon.
+        var prediction: [PredictedGlucoseValue] = []
+        var t = deliveryDate
+        while t <= deliveryDate.addingTimeInterval(model.effectDuration + .minutes(5)) {
+            prediction.append(PredictedGlucoseValue(
+                startDate: t,
+                quantity: LoopQuantity(unit: unit, doubleValue: 200.0)
+            ))
+            t = t.addingTimeInterval(.minutes(5))
+        }
+
+        // Target = 100 mg/dL constant.
+        let target: [AbsoluteScheduleValue<ClosedRange<LoopQuantity>>] = [
+            AbsoluteScheduleValue(
+                startDate: deliveryDate.addingTimeInterval(-.hours(1)),
+                endDate:   deliveryDate.addingTimeInterval(.hours(24)),
+                value: LoopQuantity(unit: unit, doubleValue: 100.0)...LoopQuantity(unit: unit, doubleValue: 100.0)
+            )
+        ]
+
+        // Schedule A: constant 50 mg/dL/U across the horizon.
+        let isfConstant: [AbsoluteScheduleValue<LoopQuantity>] = [
+            AbsoluteScheduleValue(
+                startDate: deliveryDate.addingTimeInterval(-.hours(1)),
+                endDate:   deliveryDate.addingTimeInterval(.hours(24)),
+                value: LoopQuantity(unit: unit, doubleValue: 50.0)
+            )
+        ]
+        // Schedule B: 50 mg/dL/U first half, 100 mg/dL/U second half — higher
+        // average sensitivity → fewer units needed for the same drop.
+        let isfStepped: [AbsoluteScheduleValue<LoopQuantity>] = [
+            AbsoluteScheduleValue(
+                startDate: deliveryDate.addingTimeInterval(-.hours(1)),
+                endDate:   deliveryDate.addingTimeInterval(halfHorizon),
+                value: LoopQuantity(unit: unit, doubleValue: 50.0)
+            ),
+            AbsoluteScheduleValue(
+                startDate: deliveryDate.addingTimeInterval(halfHorizon),
+                endDate:   deliveryDate.addingTimeInterval(.hours(24)),
+                value: LoopQuantity(unit: unit, doubleValue: 100.0)
+            )
+        ]
+
+        let suspend = LoopQuantity(unit: unit, doubleValue: 70.0)
+
+        let corrA = prediction.insulinCorrection(
+            to: target,
+            at: deliveryDate,
+            suspendThreshold: suspend,
+            insulinSensitivity: isfConstant,
+            model: model
+        )
+        let corrB = prediction.insulinCorrection(
+            to: target,
+            at: deliveryDate,
+            suspendThreshold: suspend,
+            insulinSensitivity: isfStepped,
+            model: model
+        )
+
+        // Extract the recommended units. Both should be in the .aboveRange case.
+        let unitsA: Double
+        let unitsB: Double
+        if case let .aboveRange(_, _, _, units) = corrA {
+            unitsA = units
+        } else {
+            XCTFail("corrA should be aboveRange"); return
+        }
+        if case let .aboveRange(_, _, _, units) = corrB {
+            unitsB = units
+        } else {
+            XCTFail("corrB should be aboveRange"); return
+        }
+        // The stepped schedule has higher integrated sensitivity (50→100 vs constant 50)
+        // → less insulin needed → unitsB < unitsA.
+        XCTAssertLessThan(unitsB, unitsA,
+            "Schedule with higher-sensitivity 2nd half should require fewer units; "
+            + "constant=\(unitsA), stepped=\(unitsB)")
+        // And specifically: a meaningful difference (not just numerical noise)
+        XCTAssertGreaterThan(unitsA - unitsB, 0.05 * unitsA,
+            "Difference should be material (>5% of constant-schedule recommendation)")
+    }
+
+    // MARK: - IOB sign behavior (today's convention)
+
+    func testIOBSumsNetBasalUnitsAcrossMixedSignDoses() {
+        // BasalRelativeDose's insulinOnBoard convolves netBasalUnits with the
+        // insulin model. A bolus contributes positive IOB; a suspend
+        // (negative net) contributes NEGATIVE IOB. Verify today's behavior at
+        // a point shortly after both doses (so neither has decayed much).
+        let start = date("2025-01-01T12:00:00")
+        let bolus = BasalRelativeDose(type: .bolus, startDate: start, endDate: start, volume: 1.0)
+        let suspend = BasalRelativeDose(
+            type: .basal(scheduledRate: 1.0),
+            startDate: start.addingTimeInterval(.hours(1)),
+            endDate:   start.addingTimeInterval(.hours(2)),
+            volume: 0.0  // net = -1
+        )
+        let iobBolus = [bolus].insulinOnBoard(at: start.addingTimeInterval(.minutes(30)))
+        let iobSuspend = [suspend].insulinOnBoard(at: start.addingTimeInterval(.hours(1) + .minutes(30)))
+        let iobBoth = [bolus, suspend].insulinOnBoard(at: start.addingTimeInterval(.hours(1) + .minutes(30)))
+
+        XCTAssertGreaterThan(iobBolus, 0, "bolus IOB positive")
+        XCTAssertLessThan(iobSuspend, 0, "suspended-temp IOB negative under current netUnits convention")
+        // Linearity: combined IOB ≈ sum of component IOBs at same eval time.
+        let iobBolusAt = [bolus].insulinOnBoard(at: start.addingTimeInterval(.hours(1) + .minutes(30)))
+        XCTAssertEqual(iobBoth, iobBolusAt + iobSuspend, accuracy: 1e-6,
+            "Combined IOB should equal sum of component IOBs (current netUnits convention)")
+    }
+}


### PR DESCRIPTION
## Summary

Loop's insulin-effect formula `effect = netBasalUnits × -ISF × pd` conflates two physically distinct quantities into a single product:

- **Active insulin** (positive `netBasalUnits`): insulin Loop actually delivered, lowering BG.
- **EGP credit** (negative `netBasalUnits`): shortfall vs scheduled basal, treated as positive BG-effect — this is the model's implicit "expected EGP rate" baked into the schedule.

Sensitivity-scaling (overrides, dynamic-ISF, etc.) scales the entire product — which means an "exercise" override that's supposed to mean "insulin works X% harder right now" also amplifies the model's EGP-credit assumption by the same factor. In a suspending regime, this makes Loop's forecasted BG rise faster than it should during a sensitivity event — exactly the opposite of what the override physically represents.

This patch decomposes the math so the two components can be scaled independently:

```
effect = max(0, nbu) × -activeSensitivity × pd
       + min(0, nbu) × -egpSensitivity   × pd
```

## API surface

- New per-dose overload: `glucoseEffect(at:activeSensitivity:egpSensitivity:delta:)` and the interval form. Existing single-ISF overloads now delegate to the decomposed version with both ISFs equal — bit-identical output.
- New collection-level overloads on `glucoseEffects` and `glucoseEffectsMidAbsorptionISF` accept an **optional** `egpSensitivityHistory`. When nil (default), single-schedule behavior is unchanged.
- `LoopAlgorithm.generatePrediction` gains optional `egpSensitivity` parameter with nil default — backward-compatible for every existing caller.

The `LoopPredictionInput`-based `generatePrediction` overload is unchanged — it doesn't yet have the `egpSensitivity` field. Callers that want the new behavior call directly.

## What this unlocks

- **Override mechanism**: an exercise preset can be expressed as `insulinSensitivity × 2, egpSensitivity = scheduled`. Insulin works 2× harder; EGP-credit unchanged. A sick-day preset can independently modulate both.
- **Real-time dynamic-ISF mechanisms**: a sensitivity-detector that boosts insulin's effectiveness can do so without amplifying the negative-IOB-as-EGP term.
- **A future model where EGP is fully decoupled from "negative IOB"** — Phase 2 will replace the EGP-credit-via-negative-net mechanism with an explicit `egpRate` schedule. The decomposed math here cleanly admits that change.

## Tests

10 new tests in `ActiveInsulinEgpDecompositionTests.swift`:

- `testDecomposedMatchesSingleISFWhenSchedulesEqual` — regression: decomposed with `activeSensitivity == egpSensitivity` matches single-ISF call exactly
- `testActiveSensitivityBoostScalesOnlyBolusEffect` — doubling active sensitivity doubles a bolus's effect
- `testEgpSensitivityDoesNotAffectBolus` — egp sensitivity has zero effect on a positive-net dose
- `testEgpSensitivityScalesOnlySuspendEffect` — egp sensitivity scales a suspended-temp; active doesn't
- `testNetZeroDoseUnaffectedByEitherSensitivity` — a temp matching scheduled basal stays at zero regardless
- `testCollectionLevelDecomposedMatchesSingleWhenSchedulesEqual` — same regression at the collection level
- `testCollectionLevelOverrideBoostsOnlyActiveComponent` — quantitative asymptote check: a bolus + suspend pair under active×2/egp×1 produces -150 (vs -100 with the over-amplifying single-schedule × 2 behavior, or -50 baseline)
- `testMidAbsorptionDecomposedMatchesSingleWhenSchedulesEqual`
- `testMidAbsorptionOverrideBoostsOnlyActiveComponent`
- `testGeneratePredictionNilEgpMatchesSingleSchedule` — end-to-end through `generatePrediction`

Also pinned by the 8 backstop tests in `Phase1BackstopTests.swift` (separate commit — see https://github.com/tidepool-org/LoopAlgorithm/pull/XX for those).

## Test plan

- [x] All existing tests pass (`xcrun swift test`)
- [x] 8 backstop tests + 10 decomposition tests pass
- [x] LoopAlgorithm builds clean